### PR TITLE
Fix/memory

### DIFF
--- a/MyFlow/DocumentViewController.swift
+++ b/MyFlow/DocumentViewController.swift
@@ -50,6 +50,13 @@ class DocumentViewController: UIViewController, PDFDocumentDelegate {
             }
         })
     }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        myNavigationView.clear()
+        pointHelper.clear()
+    }
         
     fileprivate func setMyNavigationView() {
         myNavigationView.setCurrentVC(viewController: self)

--- a/MyFlow/MyNavigationView/MyNavigationView.swift
+++ b/MyFlow/MyNavigationView/MyNavigationView.swift
@@ -58,6 +58,12 @@ class MyNavigationView: UIView {
     func setCurrentVC(viewController: DocumentViewController) { currentVC = viewController }
     func setCurrentPH(pointHelper: PointHelper) { currentPH = pointHelper }
     
+    func clear() {
+        currentVC = nil
+        currentPH = nil
+        addPointsButton.isSelected = false
+        handlePointButton.isSelected = false
+    }
     
     // MARK: Setting Buttons
     

--- a/MyFlow/PointHelper/CommandHistory/UndoRedoHistory.swift
+++ b/MyFlow/PointHelper/CommandHistory/UndoRedoHistory.swift
@@ -43,4 +43,8 @@ class UndoRedoHistory {
         print("redoCommand Undo: \(getUndoCount()) Redo: \(getRedoCount())")
     }
     
+    func clear() {
+        undoHistory.clear()
+        redoHistory.clear()
+    }
 }

--- a/MyFlow/PointHelper/PointBuilder.swift
+++ b/MyFlow/PointHelper/PointBuilder.swift
@@ -8,28 +8,21 @@
 import UIKit
 import PDFKit
 
-/// Builds the point annotaion group at specific height.
-class PointBuilder {
-    
-    /// line annotation's border.
-    private var border = PDFBorder()
+
+extension PointBuilder {
     /// pointNumber annotation's height.
-    private var pointNumberHeight = Int(MyFont.sizePointNum.height)
-    
-    init() {
-        border.lineWidth = 1.0
-    }
-    
-    
-    // MARK: Build Point Line, Number
-    
+    private static let pointNumberHeight = Int(MyFont.sizePointNum.height)
+}
+
+/// Builds the point annotaion group at specific height.
+struct PointBuilder {
     /// Returns gradient line annotation group.
     ///
     /// - Parameters:
     ///   - pageWidth: PDFPage's width. Becomes the line annotaion's length.
     ///   - height: Height position at PDFPage.
     /// - Returns: An array of line annotations each 1 px thick and 1 different in height.
-    func getPointLineGradient(pageWidth: Int, height: Int) -> [PDFAnnotation] {
+    static func getPointLineGradient(pageWidth: Int, height: Int) -> [PDFAnnotation] {
         var lines:[PDFAnnotation] = []
         for i in 0...3 {
             let line = buildPointLine(pageWidth: pageWidth, height: height - i, color: GradientColor.normal[i])
@@ -38,48 +31,18 @@ class PointBuilder {
         return lines
     }
     
-    
-    /// Returns gradient line annotation.
-    ///
-    /// - Parameters:
-    ///   - pageWidth: `PDFPage`'s width. Becomes the line annotaion's length.
-    ///   - height: Height position at `PDFPage`.
-    ///   - color: Line's color. Default is blue,
-    /// - Returns: A colored line annotation with a thickness of 1 px that exists at a certain height.
-    fileprivate func buildPointLine(pageWidth: Int, height: Int, color: UIColor = .blue) -> PDFAnnotation {
-        let bounds = CGRect(
-            origin: CGPoint(x: 0, y: height - 1),
-            size: CGSize(width: pageWidth, height: 1))
-        
-        let path = UIBezierPath()
-        path.move(to: CGPoint(x: 0, y: height))
-        path.addLine(to: CGPoint(x: pageWidth, y: height))
-        path.close()
-        path.moveCenter(to: bounds.center)
-        
-        let lineAnnotation = PDFAnnotation(
-            bounds: bounds,
-            forType: .ink,
-            withProperties: ["isPointLine": true])
-        lineAnnotation.add(path)
-        lineAnnotation.border = border
-        lineAnnotation.color = color
-        
-        return lineAnnotation
-    }
-    
     /// Returns point number annotation.
     ///
     /// - Parameters:
     ///   - number: Point's number by order.
     ///   - height: Height position at the `PDFPage`.
     /// - Returns: Point number annotation that exists at a height down by `pointNumberHeight`.
-    func getPointNumber(number: Int, height: Int) -> PDFAnnotation {
+    static func getPointNumber(number: Int, height: Int) -> PDFAnnotation {
         let str = String(number)
         
         let bounds = CGRect(
-            origin: CGPoint(x: 10, y: height - pointNumberHeight),
-            size: CGSize(width: 50, height: pointNumberHeight))
+            origin: CGPoint(x: 10, y: height - PointBuilder.pointNumberHeight),
+            size: CGSize(width: 50, height: PointBuilder.pointNumberHeight))
         let pointNumText = PDFAnnotation(
             bounds: bounds,
             forType: .widget,
@@ -97,4 +60,36 @@ class PointBuilder {
         return pointNumText
     }
     
+}
+
+extension PointBuilder {
+    /// Returns gradient line annotation.
+    ///
+    /// - Parameters:
+    ///   - pageWidth: `PDFPage`'s width. Becomes the line annotaion's length.
+    ///   - height: Height position at `PDFPage`.
+    ///   - color: Line's color. Default is blue,
+    /// - Returns: A colored line annotation with a thickness of 1 px that exists at a certain height.
+    static private func buildPointLine(pageWidth: Int, height: Int, color: UIColor = .blue) -> PDFAnnotation {
+        let bounds = CGRect(
+            origin: CGPoint(x: 0, y: height - 1),
+            size: CGSize(width: pageWidth, height: 1))
+        
+        let path = UIBezierPath()
+        path.move(to: CGPoint(x: 0, y: height))
+        path.addLine(to: CGPoint(x: pageWidth, y: height))
+        path.close()
+        path.moveCenter(to: bounds.center)
+        
+        let lineAnnotation = PDFAnnotation(
+            bounds: bounds,
+            forType: .ink,
+            withProperties: ["isPointLine": true])
+        lineAnnotation.add(path)
+        
+        lineAnnotation.border = PDFBorder().then { $0.lineWidth = 1.0 }
+        lineAnnotation.color = color
+        
+        return lineAnnotation
+    }
 }

--- a/MyFlow/PointHelper/PointHelper.swift
+++ b/MyFlow/PointHelper/PointHelper.swift
@@ -31,9 +31,6 @@ class PointHelper {
     /// Current point line annotations selected by user.
     var nowSelectedPointLines:[PDFAnnotation] = []
     
-    /// The object that actually builds the point annotaion groups when user add it.
-    let pointBuilder = PointBuilder()
-    
     
     // MARK: Getter, Setter
     
@@ -244,8 +241,8 @@ extension PointHelper {
         let pageWidth = page.bounds(for: PDFDisplayBox.mediaBox).size.width
         
         var change: [PDFAnnotation] = []
-        change.append(pointBuilder.getPointNumber(number: number, height: height))
-        change.append(contentsOf: pointBuilder.getPointLineGradient(pageWidth: Int(pageWidth), height: height))
+        change.append(PointBuilder.getPointNumber(number: number, height: height))
+        change.append(contentsOf: PointBuilder.getPointLineGradient(pageWidth: Int(pageWidth), height: height))
         
         let command = AddCommand(pointHelper: self,
                                  change: change,

--- a/MyFlow/PointHelper/PointHelper.swift
+++ b/MyFlow/PointHelper/PointHelper.swift
@@ -59,6 +59,15 @@ class PointHelper {
         commandHistory.redoCommand()
     }
     
+    func clear() {
+        commandHistory.clear()
+    }
+    
+    #if DEBUG
+    deinit {
+        print("PointHelper deinit")
+    }
+    #endif
 }
 
 


### PR DESCRIPTION
## 기존
- 유저가 화면을 나가도, 네비게이션 뷰가 currentVC와 currentPH를 가지고 있음
- pointHelper의 history의 커맨드가 pointHelper를 참조하고 있음
따라서 PointHelper와 참조하는 클래스들(PDFPage 등)이 정상적으로 deinit이 안 되는 문제가 있었습니다.

## 해결
현재 문서 화면을 나갈 경우 참조 정보들을 지워 메모리 해제가 가능하도록 합니다.