### PR TITLE
Feature/file helper

### DIFF
--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AF255AA5283E95C900747FF3 /* ThumbnailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF255AA4283E95C900747FF3 /* ThumbnailCell.swift */; };
 		AF2A9ACA28615C2200D0BB24 /* DeleteCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2A9AC928615C2200D0BB24 /* DeleteCommand.swift */; };
 		AF3C3F972843C0C2007ED4F9 /* DocumentViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3C3F962843C0C2007ED4F9 /* DocumentViewState.swift */; };
+		AF65F790292E4E5F0005D9AF /* FileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF65F78F292E4E5F0005D9AF /* FileHelper.swift */; };
 		AF8936BA2836655C001031FC /* PointBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8936B92836655C001031FC /* PointBuilder.swift */; };
 		AF8936BC28367FD2001031FC /* MyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8936BB28367FD2001031FC /* MyError.swift */; };
 		AF8EDF7F282E3F7A00CCFF19 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF8EDF7E282E3F7A00CCFF19 /* AppDelegate.swift */; };
@@ -67,6 +68,7 @@
 		AF255AA4283E95C900747FF3 /* ThumbnailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThumbnailCell.swift; sourceTree = "<group>"; };
 		AF2A9AC928615C2200D0BB24 /* DeleteCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteCommand.swift; sourceTree = "<group>"; };
 		AF3C3F962843C0C2007ED4F9 /* DocumentViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewState.swift; sourceTree = "<group>"; };
+		AF65F78F292E4E5F0005D9AF /* FileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHelper.swift; sourceTree = "<group>"; };
 		AF8936B92836655C001031FC /* PointBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointBuilder.swift; sourceTree = "<group>"; };
 		AF8936BB28367FD2001031FC /* MyError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyError.swift; sourceTree = "<group>"; };
 		AF8EDF7B282E3F7A00CCFF19 /* MyFlow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MyFlow.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -125,6 +127,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AF65F78E292E4E4D0005D9AF /* FileHelper */ = {
+			isa = PBXGroup;
+			children = (
+				AF65F78F292E4E5F0005D9AF /* FileHelper.swift */,
+			);
+			path = FileHelper;
+			sourceTree = "<group>";
+		};
 		AF8EDF72282E3F7A00CCFF19 = {
 			isa = PBXGroup;
 			children = (
@@ -149,6 +159,7 @@
 		AF8EDF7D282E3F7A00CCFF19 /* MyFlow */ = {
 			isa = PBXGroup;
 			children = (
+				AF65F78E292E4E4D0005D9AF /* FileHelper */,
 				AFD6DE352834000B00E9FA5E /* DocumentHelper */,
 				AFD6DE342833FFFF00E9FA5E /* PointHelper */,
 				AFD6DE332833FFDC00E9FA5E /* MyNavigationView */,
@@ -498,6 +509,7 @@
 				AF255AA1283E809E00747FF3 /* UIDeviceExtension.swift in Sources */,
 				AF98A38C2832A6590035601D /* UIFontExtension.swift in Sources */,
 				AF98A38E2832A6760035601D /* UIColorExtension.swift in Sources */,
+				AF65F790292E4E5F0005D9AF /* FileHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MyFlow/DocumentViewController.swift
+++ b/MyFlow/DocumentViewController.swift
@@ -43,6 +43,12 @@ class DocumentViewController: UIViewController, PDFDocumentDelegate {
                     print("This file cannot be commented")
                 }
                 setMoveStrategy()
+                
+                if let pointsInfos = FileHelper.shared.readPointsFileIfExist(absoluteString: document!.fileURL.absoluteString) {
+                    pointsInfos.forEach { info in
+                        pointHelper.addPoint(info.height, pdfDocument.page(at: info.page)!)
+                    }
+                }
             }
             else {
                 print("error")
@@ -56,6 +62,13 @@ class DocumentViewController: UIViewController, PDFDocumentDelegate {
         
         myNavigationView.clear()
         pointHelper.clear()
+        
+        let pointsInfos = pointHelper
+            .getPointsInfo()
+            .map { (height, page) in
+                PointsInfo(height: height, page: pdfDocument!.index(for: page))
+            }
+        FileHelper.shared.writePointsFile(absoluteString: document!.fileURL.absoluteString, pointsInfos: pointsInfos)
     }
         
     fileprivate func setMyNavigationView() {

--- a/MyFlow/FileHelper/FileHelper.swift
+++ b/MyFlow/FileHelper/FileHelper.swift
@@ -1,0 +1,112 @@
+//
+//  FileHelper.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2022/11/23.
+//
+
+import UIKit
+import SQLite3
+
+struct PointsFile: Codable {
+    var fileUrl: String
+    var key: Int
+}
+
+struct PointsInfo: Codable {
+    var height: Int
+    var page: Int
+}
+
+/// Manages file read/write.
+///
+/// If there is previously edited information, read it.
+/// Save edited point information with the file path as identifier.
+class FileHelper {
+    
+    static let shared = FileHelper()
+    let fileManager: FileManager
+    let documentsURL: URL
+    let directoryURL: URL
+    let pointsDictPath: URL
+    
+    var dict: [PointsFile] = []
+
+    private init() {
+        fileManager = FileManager.default
+        documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        directoryURL = documentsURL.appendingPathComponent("points")
+        pointsDictPath = directoryURL.appendingPathComponent("points")
+        
+        makeDirectoryIfNeeded()
+        
+        dict = readPointsDict()
+    }
+    
+    private func readPointsDict() -> [PointsFile] {
+        do {
+            let data = try Data(contentsOf: pointsDictPath)
+            let dict = try JSONDecoder().decode([PointsFile].self, from: data)
+            print("Find PointsFileDict: \(dict)")
+            return dict
+        } catch let e {
+            print(e.localizedDescription)
+            return []
+        }
+    }
+    
+    private func makeDirectoryIfNeeded() {
+        do {
+            try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: false, attributes: nil)
+        } catch let e {
+            print(e.localizedDescription)
+        }
+    }
+    
+    func readPointsFileIfExist(absoluteString: String) -> [PointsInfo]? {
+        if let pointsFile = dict.first(where: { $0.fileUrl == absoluteString }) {
+            print("Find PointsFile: \(pointsFile)")
+            let pointsFilePath = directoryURL.appendingPathComponent("\(pointsFile.key)")
+            do {
+                let data = try Data(contentsOf: pointsFilePath)
+                let pointsInfos = try JSONDecoder().decode([PointsInfo].self, from: data)
+                print("Find PointsInfos: \(pointsInfos)")
+                return pointsInfos
+            } catch let e {
+                print(e.localizedDescription)
+                return nil
+            }
+        }
+        return nil
+    }
+    
+    func writePointsFile(absoluteString: String, pointsInfos: [PointsInfo]) {
+        let pointsFile = dict.first(where: { $0.fileUrl == absoluteString }) ?? addNewPointsFile(absoluteString: absoluteString)
+        
+        let pointsFilePath = directoryURL.appendingPathComponent("\(pointsFile.key)")
+        do {
+            let jsonData = try JSONEncoder().encode(pointsInfos)
+            try jsonData.write(to: pointsFilePath)
+        } catch {
+            print("Error writing to JSON file: \(error)")
+        }
+    }
+    
+    private func addNewPointsFile(absoluteString: String) -> PointsFile {
+        let pointsFile = PointsFile(fileUrl: absoluteString, key: dict.count + 1)
+        dict.append(pointsFile)
+        writePointsDict()
+        return pointsFile
+    }
+    
+    private func writePointsDict() {
+        do {
+            let jsonData = try JSONEncoder().encode(dict)
+            try jsonData.write(to: pointsDictPath)
+        } catch {
+            print("Error writing to JSON file: \(error)")
+        }
+    }
+    
+}
+

--- a/MyFlow/PointHelper/PointBuilder.swift
+++ b/MyFlow/PointHelper/PointBuilder.swift
@@ -11,7 +11,7 @@ import PDFKit
 
 extension PointBuilder {
     /// pointNumber annotation's height.
-    private static let pointNumberHeight = Int(MyFont.sizePointNum.height)
+    static let pointNumberHeight = Int(MyFont.sizePointNum.height)
 }
 
 /// Builds the point annotaion group at specific height.

--- a/MyFlow/PointHelper/PointHelper.swift
+++ b/MyFlow/PointHelper/PointHelper.swift
@@ -36,7 +36,13 @@ class PointHelper {
     
     func getPointsCount() -> Int { points.count }
     func getNowSelectedPoint() -> PDFAnnotation? { nowSelectedPoint }
-        
+    
+    func getPointsInfo() -> [(Int, PDFPage)] {
+        points.compactMap { annotaion in
+            (Int(annotaion.bounds.origin.y) + PointBuilder.pointNumberHeight, annotaion.page) as? (Int, PDFPage)
+        }
+    }
+    
     func createMemento() -> PointHelperMemento {
         return PointHelperMemento(points: points, linesDict: linesDict)
     }


### PR DESCRIPTION
## Add `FileHelper`
When new pdf file is opened, read the previously edited information if exists.
When file is closed, save edited point information with the file path as identifier.