### PR TITLE
Fix/change tabs

### DIFF
--- a/MyFlow/DocumentView/States/DocumentViewState.swift
+++ b/MyFlow/DocumentView/States/DocumentViewState.swift
@@ -11,6 +11,8 @@ import PDFKit
 
 /// State that is not any modes(adding, handling). If user touches the screen, navigation is toggled.
 struct NormalState: DocumentViewStateInterface {
+    private(set) var state: DocumentViewState = .normal
+    
     private(set) weak var vm: DocumentViewModel?
     
     func tapProcess(location: CGPoint, pdfView: PDFView) {
@@ -20,6 +22,8 @@ struct NormalState: DocumentViewStateInterface {
 
 /// State that handling points. User can select and move points at this state.
 struct HandlePointsState: DocumentViewStateInterface {
+    private(set) var state: DocumentViewState = .handlePoints
+    
     private(set) weak var vm: DocumentViewModel?
     
     /// Move selected points to `location`.
@@ -39,6 +43,8 @@ struct HandlePointsState: DocumentViewStateInterface {
 
 /// State that adding points. User can  add new points at this state.
 struct AddPointsState: DocumentViewStateInterface {
+    private(set) var state: DocumentViewState = .addPoints
+    
     private(set) weak var vm: DocumentViewModel?
     
     /// add new point to `location`.
@@ -54,6 +60,8 @@ struct AddPointsState: DocumentViewStateInterface {
 
 /// Play mode. At this state, user can move to previous point with touching left side and next point with toucing right side.
 struct PlayModeState: DocumentViewStateInterface {
+    private(set) var state: DocumentViewState = .playMode
+    
     private(set) weak var vm: DocumentViewModel?
     
     /// Move to previous point with touching left side and next point with toucing right side.

--- a/MyFlow/DocumentView/States/DocumentViewStateInterface.swift
+++ b/MyFlow/DocumentView/States/DocumentViewStateInterface.swift
@@ -15,5 +15,6 @@ enum DocumentViewState {
 }
 
 protocol DocumentViewStateInterface {
+    var state: DocumentViewState { get }
     func tapProcess(location: CGPoint, pdfView: PDFView)
 }

--- a/MyFlow/DocumentView/ViewModel/DocumentViewModel.swift
+++ b/MyFlow/DocumentView/ViewModel/DocumentViewModel.swift
@@ -9,6 +9,10 @@ import PDFKit
 
 
 final class DocumentViewModel: NSObject, PDFDocumentDelegate {
+    var key: URL? {
+        document?.fileURL
+    }
+    
     
     weak var delegate: DocumentViewDelegate?
     

--- a/MyFlow/MainView/ViewModel/MainViewModel.swift
+++ b/MyFlow/MainView/ViewModel/MainViewModel.swift
@@ -38,13 +38,17 @@ extension MainViewModel: DocumentTabsCollectionDataSource {
         nowIndex = index
     }
     
-    func getItem(at index: Int) -> String {
-        return documentViews[index].title ?? ""
+    func getItem(at index: Int) -> (String, URL?) {
+        return (documentViews[index].title ?? "", documentViews[index].viewModel?.key)
     }
     
-    func closeTab(at index: Int) -> Int? {
-        // TODO: Close document logic(saving points, showing message, switch to next index if needed, ...)
+    func closeTab(key: URL?) -> Int? {
+        guard let index = documentViews.firstIndex(where:{ $0.viewModel?.key == key }) else {
+            return nil
+        }
         
+        // TODO: Close document logic(saving points, showing message, switch to next index if needed, ...)
+        print(index, "삭제")
         documentViews[index].close()
         if index == nowIndex {
             delegate?.removeDocumentView(with: documentViews[index])
@@ -99,7 +103,7 @@ extension MainViewModel: DocumentTabsCollectionDataSource {
 
 extension MainViewModel: MainViewModelInterface {
     func openDocument(_ vc: DocumentViewController) {
-        if let idx = documentViews.firstIndex(where: { $0.viewModel?.document?.fileURL == vc.viewModel?.document?.fileURL }) {
+        if let idx = documentViews.firstIndex(where: { $0.viewModel?.key == vc.viewModel?.key }) {
             // reopen
             nowIndex = idx
         } else {

--- a/MyFlow/MainView/Views/MainViewController.swift
+++ b/MyFlow/MainView/Views/MainViewController.swift
@@ -169,11 +169,13 @@ extension MainViewController: MainViewDelegate {
         endPlayModeButton.isHidden = false
     }
     
-    func updateDocumentView(with vc: DocumentViewController) {
+    func updateDocumentView(with vc: DocumentViewController, info: DocumentTabInfo) {
         if let beforeState = myNavigationView.viewModel.currentVM?.nowState?.state {
             vc.viewModel?.changeState(to: beforeState)
         }
         myNavigationView.viewModel.currentVM = vc.viewModel
+        
+        myNavigationView.setPointNum(with: info.nowPointNum)
         showDocumentView(with: vc)
     }
     

--- a/MyFlow/MainView/Views/MainViewController.swift
+++ b/MyFlow/MainView/Views/MainViewController.swift
@@ -170,6 +170,9 @@ extension MainViewController: MainViewDelegate {
     }
     
     func updateDocumentView(with vc: DocumentViewController) {
+        if let beforeState = myNavigationView.viewModel.currentVM?.nowState?.state {
+            vc.viewModel?.changeState(to: beforeState)
+        }
         myNavigationView.viewModel.currentVM = vc.viewModel
         showDocumentView(with: vc)
     }

--- a/MyFlow/MainView/Views/MainViewDelegate.swift
+++ b/MyFlow/MainView/Views/MainViewDelegate.swift
@@ -12,6 +12,6 @@ protocol MainViewDelegate: NSObject {
     func dismiss()
     func playModeStart()
     
-    func updateDocumentView(with vc: DocumentViewController)
+    func updateDocumentView(with vc: DocumentViewController, info: DocumentTabInfo)
     func removeDocumentView(with vc: DocumentViewController)
 }

--- a/MyFlow/MyNavigationView/ViewModel/MyNavigationViewModel.swift
+++ b/MyFlow/MyNavigationView/ViewModel/MyNavigationViewModel.swift
@@ -13,7 +13,7 @@ final class MyNavigationViewModel {
     weak var delegate: MyNavigationViewDelegate?
     
     weak var mainViewDelegate: MainViewDelegate?
-    weak var currentVM: DocumentViewModelInterface?
+    var currentVM: DocumentViewModel?
     
 }
 

--- a/MyFlow/MyNavigationView/Views/Subviews/DocumentTabsCollectionViewAdaptor.swift
+++ b/MyFlow/MyNavigationView/Views/Subviews/DocumentTabsCollectionViewAdaptor.swift
@@ -12,8 +12,8 @@ protocol DocumentTabsCollectionDataSource: NSObjectProtocol {
     func numberOfItems() -> Int
     func getSelectedIndex() -> Int
     func setSelectedIndex(with index: Int)
-    func getItem(at index: Int) -> String
-    func closeTab(at index: Int) -> Int?
+    func getItem(at index: Int) -> (String, URL?)
+    func closeTab(key: URL?) -> Int?
     func openTab(from before: Int, to after: Int)
     func moveTab(from before: Int, to after: Int)
 }
@@ -69,11 +69,11 @@ extension DocumentTabsCollectionViewAdaptor: UICollectionViewDataSource {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TabCell", for: indexPath) as! TabCell
         
         let item = dataSource?.getItem(at: indexPath.row)
-        cell.label.text = item
+        cell.label.text = item?.0 ?? ""
         
         cell.deleteAction = {
-            print("Delete \(item)")
-            if let next = self.dataSource?.closeTab(at: indexPath.item) {
+            print("Delete \(item?.0), \(item?.1)")
+            if let next = self.dataSource?.closeTab(key: item?.1) {
                 self.dataSource?.setSelectedIndex(with: next)
                 collectionView.cellForItem(at: IndexPath(item: next, section: 0))?.isSelected = true
             }


### PR DESCRIPTION
### Set the state same with the previous
There was a problem that point selection was not possible because the state of the current view and the state of the other tabs to be changed were different.
So when the tab changes, Make the state same.

### Delete the tab with the key, not the index
There was a problem that the index of deleteAction was not updated when the order was changed by drag&drop.
Therefore, delete with a unique key, not the index of the collectionView.