### PR TITLE
Feat/save points info

### DIFF
--- a/MyFlow/SceneDelegate.swift
+++ b/MyFlow/SceneDelegate.swift
@@ -40,6 +40,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillResignActive(_ scene: UIScene) {
         // Called when the scene will move from an active state to an inactive state.
         // This may occur due to temporary interruptions (ex. an incoming phone call).
+        
+        MainViewModel.shared.savePointsInfos()
+        
         if let mainVC = window!.rootViewController?.presentedViewController as? MainViewController {
             logger.log("sceneWillResignActive: Set scene's userActivity")
             scene.userActivity = mainVC.mainViewUserActivity
@@ -57,7 +60,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
 
         // Save changes in the application's managed object context when the application transitions to the background.
-//        (UIApplication.shared.delegate as? AppDelegate)?.saveContext()
+        
+        MainViewModel.shared.savePointsInfos()
     }
 
 

--- a/MyFlow/Utilities/PointHelper/PointCommand/AddCommand.swift
+++ b/MyFlow/Utilities/PointHelper/PointCommand/AddCommand.swift
@@ -22,7 +22,7 @@ class AddCommand: PointCommand {
     }
     
     // TODO: Should be able to process multiple points at once - AddpointsModalViewController
-    func execute() {
+    func concreteExecute() {
         guard let number = Int(change[0].widgetStringValue ?? "") else {
             return
         }
@@ -34,7 +34,7 @@ class AddCommand: PointCommand {
         }
     }
     
-    func undo() {
+    func concreteUndo() {
         pointHelper.points = backup.points
         pointHelper.linesDict = backup.linesDict
         change.forEach {

--- a/MyFlow/Utilities/PointHelper/PointCommand/DeleteCommand.swift
+++ b/MyFlow/Utilities/PointHelper/PointCommand/DeleteCommand.swift
@@ -16,7 +16,7 @@ class DeleteCommand: PointCommand {
         self.backup = backup
     }
     
-    func execute() {
+    func concreteExecute() {
         guard let number = Int(backup.change[0].widgetStringValue ?? "") else {
             return
         }
@@ -37,7 +37,7 @@ class DeleteCommand: PointCommand {
         }
     }
     
-    func undo() {
+    func concreteUndo() {
         guard let number = Int(backup.change[0].widgetStringValue ?? "") else {
             return
         }

--- a/MyFlow/Utilities/PointHelper/PointCommand/MoveCommand.swift
+++ b/MyFlow/Utilities/PointHelper/PointCommand/MoveCommand.swift
@@ -21,11 +21,11 @@ class MoveCommand: PointCommand {
         self.after = after
     }
     
-    func execute() {
+    func concreteExecute() {
         movePoint(from: backup, to: after)
     }
     
-    func undo() {
+    func concreteUndo() {
         movePoint(from: after, to: backup)
     }
     

--- a/MyFlow/Utilities/PointHelper/PointCommand/PointCommand.swift
+++ b/MyFlow/Utilities/PointHelper/PointCommand/PointCommand.swift
@@ -13,4 +13,21 @@ protocol PointCommand {
     
     func execute()
     func undo()
+    
+    func concreteExecute()
+    func concreteUndo()
+}
+
+extension PointCommand {
+    func execute() {
+        concreteExecute()
+        
+        pointHelper.isEdited = true
+    }
+    
+    func undo() {
+        concreteUndo()
+        
+        pointHelper.isEdited = true
+    }
 }

--- a/MyFlow/Utilities/PointHelper/PointHelper.swift
+++ b/MyFlow/Utilities/PointHelper/PointHelper.swift
@@ -39,10 +39,16 @@ class PointHelper {
     func getPointsCount() -> Int { points.count }
     func getNowSelectedPoint() -> PDFAnnotation? { nowSelectedPoint }
     
-    func getPointsInfo() -> [(Int, PDFPage)] {
-        points.compactMap { annotaion in
-            (Int(annotaion.bounds.origin.y) + PointBuilder.pointNumberHeight, annotaion.page) as? (Int, PDFPage)
-        }
+    func getPointsInfos(in pdfDocument: PDFDocument) -> [PointsInfo] {
+        points
+            .compactMap { annotaion in
+                if let page = annotaion.page {
+                    return PointsInfo(height: Int(annotaion.bounds.origin.y)
+                                        + PointBuilder.pointNumberHeight,
+                                      page: pdfDocument.index(for: page))
+                }
+                return nil
+            }
     }
     
     func createMemento() -> PointHelperMemento {

--- a/MyFlow/Utilities/PointHelper/PointHelper.swift
+++ b/MyFlow/Utilities/PointHelper/PointHelper.swift
@@ -33,6 +33,8 @@ class PointHelper {
     /// Current point line annotations selected by user.
     var nowSelectedPointLines:[PDFAnnotation] = []
     
+    /// A Boolean variable indicating whether the point information has been modified.
+    var isEdited = false
     
     // MARK: Getter, Setter
     

--- a/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
+++ b/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
@@ -53,10 +53,14 @@ final class DocumentViewModel: NSObject, PDFDocumentDelegate {
     
     func clear() {
         pointHelper.clear()
-        savePointsInfos()
+        savePointsInfosIfNeeded()
     }
     
-    func savePointsInfos() {
+    func savePointsInfosIfNeeded() {
+        if !pointHelper.isEdited {
+            return
+        }
+        
         guard let document = document,
               let pdfDocument = pdfDocument else {
             logger.log("Cant' savePointsInfos \(key?.lastPathComponent ?? ""): document or pdfDocument is nil", .error)
@@ -66,6 +70,8 @@ final class DocumentViewModel: NSObject, PDFDocumentDelegate {
         logger.log("savePointsInfos \(key?.lastPathComponent ?? "")")
         FileHelper.shared.writePointsFile(absoluteString: document.fileURL.absoluteString,
                                           pointsInfos: pointHelper.getPointsInfos(in: pdfDocument))
+        
+        pointHelper.isEdited = false
     }
     
 }

--- a/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
+++ b/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
@@ -53,13 +53,19 @@ final class DocumentViewModel: NSObject, PDFDocumentDelegate {
     
     func clear() {
         pointHelper.clear()
+        savePointsInfos()
+    }
+    
+    func savePointsInfos() {
+        guard let document = document,
+              let pdfDocument = pdfDocument else {
+            logger.log("Cant' savePointsInfos \(key?.lastPathComponent ?? ""): document or pdfDocument is nil", .error)
+            return
+        }
         
-        let pointsInfos = pointHelper
-            .getPointsInfo()
-            .map { (height, page) in
-                PointsInfo(height: height, page: pdfDocument!.index(for: page))
-            }
-        FileHelper.shared.writePointsFile(absoluteString: document!.fileURL.absoluteString, pointsInfos: pointsInfos)
+        logger.log("savePointsInfos \(key?.lastPathComponent ?? "")")
+        FileHelper.shared.writePointsFile(absoluteString: document.fileURL.absoluteString,
+                                          pointsInfos: pointHelper.getPointsInfos(in: pdfDocument))
     }
     
 }

--- a/MyFlow/ViewModels/MainView/MainViewModel.swift
+++ b/MyFlow/ViewModels/MainView/MainViewModel.swift
@@ -41,7 +41,7 @@ extension MainViewModel {
     func savePointsInfos() {
         documentViews
             .forEach { vc in
-                vc.viewModel?.savePointsInfos()
+                vc.viewModel?.savePointsInfosIfNeeded()
             }
     }
     

--- a/MyFlow/ViewModels/MainView/MainViewModel.swift
+++ b/MyFlow/ViewModels/MainView/MainViewModel.swift
@@ -38,6 +38,13 @@ final class MainViewModel: NSObject {
 
 
 extension MainViewModel {
+    func savePointsInfos() {
+        documentViews
+            .forEach { vc in
+                vc.viewModel?.savePointsInfos()
+            }
+    }
+    
     private func saveTabInfo(_ index: Int) {
         infos[index].nowPointNum = documentViews[index].viewModel?.getNowPointNum() ?? 1
         infos[index].offset = documentViews[index].pdfView.scrollView?.contentOffset ?? .zero


### PR DESCRIPTION
### Apply Template method pattern to `PointCommand`
All commands must set `isEdited` after execution or undoing, so apply Template method pattern.

### Add state `isEdited` to `PointHelper`
A Boolean variable indicating whether the point information has been modified.

### Add save pointInfos logic
Saves the PointsInfo of all open documents when user leave the scene.