### PR TITLE
Fix/open tab memory leaks

### DIFF
--- a/MyFlow/Utilities/UserActivityHelper/UserActivityHelper.swift
+++ b/MyFlow/Utilities/UserActivityHelper/UserActivityHelper.swift
@@ -25,11 +25,7 @@ extension UserActivityHelper {
         return userActivity
     }
     
-    private static func getBookmark(from url: URL?) -> Data? {
-        guard let url = url else {
-            logger.log("url is nil", .error)
-            return nil
-        }
+    private static func getBookmark(from url: URL) -> Data? {
         do {
             let bookmarkData = try url.bookmarkData(options: .minimalBookmark, includingResourceValuesForKeys: nil, relativeTo: nil)
             return bookmarkData
@@ -72,10 +68,10 @@ extension UserActivityHelper {
     private static func getURL(from bookmark: Data) -> URL? {
         do {
             var isStale = false
-            var url = try URL(resolvingBookmarkData: bookmark, bookmarkDataIsStale: &isStale)
+            let url = try URL(resolvingBookmarkData: bookmark, bookmarkDataIsStale: &isStale)
             if isStale {
                 logger.log("Bookmark(\(url.lastPathComponent)) is stale")
-                let updatedBookmark = try url.bookmarkData()
+                _ = try url.bookmarkData()
             }
             return url
         } catch let error {

--- a/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
+++ b/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
@@ -76,19 +76,22 @@ extension DocumentViewModel {
         let isSuccess = await document.open()
         
         if isSuccess {
-            openSuccess()
+            try openSuccess()
         } else {
             try openFail()
         }
     }
     
-    func openSuccess() {
+    func openSuccess() throws {
         logger.log("Success to read file: \(document.fileURL.lastPathComponent)")
         
-        self.pdfDocument = PDFDocument(url: document.fileURL)
-        guard let pdfDocument = self.pdfDocument else { return }
+        guard let pdfDocument = PDFDocument(url: document.fileURL) else {
+            logger.log("Fail to get pdf file: \(document.fileURL.absoluteString)", .error)
+            throw PdfError.cannotFindDocument
+        }
+        self.pdfDocument = pdfDocument
         pdfDocument.delegate = self
-        if pdfDocument.allowsCommenting == false {
+        if !pdfDocument.allowsCommenting {
             // TODO: presenting an message to the user.
             logger.log("This file cannot be commented", .info)
         }

--- a/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
+++ b/MyFlow/ViewModels/DocumentView/DocumentViewModel.swift
@@ -11,14 +11,14 @@ import PDFKit
 final class DocumentViewModel: NSObject, PDFDocumentDelegate {
     let logger = MyLogger(category: String(describing: DocumentViewModel.self))
     
-    var key: URL? {
-        document?.fileURL
+    var key: URL {
+        document.fileURL
     }
     
     
     weak var delegate: DocumentViewDelegate?
     
-    var document: UIDocument?
+    var document: UIDocument
     var pdfDocument: PDFDocument?
     
     var nowState: DocumentViewStateInterface? {
@@ -56,13 +56,12 @@ final class DocumentViewModel: NSObject, PDFDocumentDelegate {
             return
         }
         
-        guard let document = document,
-              let pdfDocument = pdfDocument else {
-            logger.log("Cant' savePointsInfos \(key?.lastPathComponent ?? ""): document or pdfDocument is nil", .error)
+        guard let pdfDocument = pdfDocument else {
+            logger.log("Cant' savePointsInfos \(key.lastPathComponent): pdfDocument is nil", .error)
             return
         }
         
-        logger.log("savePointsInfos \(key?.lastPathComponent ?? "")")
+        logger.log("savePointsInfos \(key.lastPathComponent)")
         FileHelper.shared.writePointsFile(absoluteString: document.fileURL.absoluteString,
                                           pointsInfos: pointHelper.getPointsInfos(in: pdfDocument))
         
@@ -74,8 +73,6 @@ final class DocumentViewModel: NSObject, PDFDocumentDelegate {
 // MARK: Prepare
 extension DocumentViewModel {
     func openDocument() async throws {
-        guard let document = document else { return }
-        
         let isSuccess = await document.open()
         
         if isSuccess {
@@ -86,8 +83,6 @@ extension DocumentViewModel {
     }
     
     func openSuccess() {
-        guard let document = document else { return }
-        
         logger.log("Success to read file: \(document.fileURL.lastPathComponent)")
         
         self.pdfDocument = PDFDocument(url: document.fileURL)
@@ -106,8 +101,6 @@ extension DocumentViewModel {
     }
     
     func openFail() throws {
-        guard let document = document else { return }
-        
         logger.log("Fail to read file: \(document.fileURL.absoluteString)", .error)
         throw PdfError.cannotFindDocument
     }

--- a/MyFlow/ViewModels/MainView/MainViewModel.swift
+++ b/MyFlow/ViewModels/MainView/MainViewModel.swift
@@ -9,7 +9,7 @@ import UIKit
 
 
 struct DocumentTabInfo {
-    var url: URL?
+    var url: URL
     var nowPointNum: Int = 1
     var offset: CGPoint = .zero
     var scaleFactor: CGFloat = 1.0
@@ -41,12 +41,12 @@ extension MainViewModel {
     func savePointsInfos() {
         documentViews
             .forEach { vc in
-                vc.viewModel?.savePointsInfosIfNeeded()
+                vc.viewModel.savePointsInfosIfNeeded()
             }
     }
     
     private func saveTabInfo(_ index: Int) {
-        infos[index].nowPointNum = documentViews[index].viewModel?.getNowPointNum() ?? 1
+        infos[index].nowPointNum = documentViews[index].viewModel.getNowPointNum()
         infos[index].offset = documentViews[index].pdfView.scrollView?.contentOffset ?? .zero
         infos[index].scaleFactor = documentViews[index].pdfView.scaleFactor
     }
@@ -68,16 +68,16 @@ extension MainViewModel: DocumentTabsCollectionDataSource {
     }
     
     func getItem(at index: Int) -> (String, URL?) {
-        return (infos[index].url?.lastPathComponent ?? "", infos[index].url)
+        return (infos[index].url.lastPathComponent, infos[index].url)
     }
     
     func closeTab(key: URL?) -> Int? {
-        guard let index = documentViews.firstIndex(where:{ $0.viewModel?.key == key }) else {
+        guard let index = documentViews.firstIndex(where:{ $0.viewModel.key == key }) else {
             return nil
         }
         
         // TODO: Close document logic(saving points, showing message, switch to next index if needed, ...)
-        logger.log("Delete tab\(index) \(infos[index].url?.lastPathComponent ?? "")")
+        logger.log("Delete tab\(index) \(infos[index].url.lastPathComponent)")
         documentViews[index].close()
         if index == nowIndex {
             delegate?.removeDocumentView(with: documentViews[index])
@@ -153,12 +153,12 @@ extension MainViewModel: MainViewModelInterface {
         if let info = info {
             infos.append(info)
         } else {
-            infos.append(DocumentTabInfo(url: vc.viewModel?.key))
+            infos.append(DocumentTabInfo(url: vc.viewModel.key))
         }
     }
     
     func changeCurrentDocumentState(to state: DocumentViewState) {
-        documentViews[nowIndex].viewModel?.changeState(to: state)
+        documentViews[nowIndex].viewModel.changeState(to: state)
     }
     
     func getNowDocumentViewController() -> DocumentViewController? {
@@ -215,10 +215,10 @@ extension MainViewModel: MainViewModelInterface {
                 .forEach { (i, info) in
                     group.addTask {
                         do {
-                            let viewModel = try await DocumentViewModel(document: Document(fileURL: info.url!))
+                            let viewModel = try await DocumentViewModel(document: Document(fileURL: info.url))
                             return (i, viewModel, info)
                         } catch {
-                            self.logger.log("Fail to make viewModel with \(info.url!.lastPathComponent)", .error)
+                            self.logger.log("Fail to make viewModel with \(info.url.lastPathComponent)", .error)
                             return nil
                         }
                     }

--- a/MyFlow/ViewModels/MainView/MainViewModelInterface.swift
+++ b/MyFlow/ViewModels/MainView/MainViewModelInterface.swift
@@ -9,7 +9,7 @@ import Foundation
 
 
 protocol MainViewModelInterface {
-    func openDocument(_ vc: DocumentViewController)
+    func openDocument(with url: URL, completion: (() -> ())?)
     func getNowDocumentViewController() -> DocumentViewController?
     func changeCurrentDocumentState(to state: DocumentViewState)
     

--- a/MyFlow/Views/DocumentBrowserView/DocumentBrowserViewController.swift
+++ b/MyFlow/Views/DocumentBrowserView/DocumentBrowserViewController.swift
@@ -62,17 +62,10 @@ class DocumentBrowserViewController: UIDocumentBrowserViewController, UIDocument
     // MARK: Document Presentation
     
     func presentDocument(at documentURL: URL) {
-        Task {
-            let viewModel = try! await DocumentViewModel(document: Document(fileURL: documentURL))
-            DispatchQueue.main.async {
-                let documentViewController = DocumentViewController(viewModel: viewModel)
-                
-                let mainVC = MainViewController(initialVC: documentViewController)
-                mainVC.modalPresentationStyle = .fullScreen
-                
-                self.present(mainVC, animated: true, completion: nil)
-            }
-        }
+        let mainVC = MainViewController(initialURL: documentURL)
+        mainVC.modalPresentationStyle = .fullScreen
+        
+        self.present(mainVC, animated: true, completion: nil)
     }
 }
 

--- a/MyFlow/Views/DocumentView/DocumentViewController.swift
+++ b/MyFlow/Views/DocumentView/DocumentViewController.swift
@@ -21,7 +21,7 @@ final class DocumentViewController: UIViewController {
     var stateLabel = UILabel()
 #endif
     
-    var viewModel: DocumentViewModel?
+    var viewModel: DocumentViewModel
     
     var restoreInfo: DocumentTabInfo?
     
@@ -33,7 +33,7 @@ final class DocumentViewController: UIViewController {
         
         super.init(nibName: nil, bundle: nil)
         
-        self.viewModel?.moveStrategy = getMoveStrategy()
+        self.viewModel.moveStrategy = getMoveStrategy()
         
         configure()
     }
@@ -53,7 +53,7 @@ final class DocumentViewController: UIViewController {
         super.viewDidLayoutSubviews()
         
         if let documentTabInfo = restoreInfo {
-            logger.log("\(viewModel?.key?.lastPathComponent ?? "nil") Restore Info: scaleFactor \(documentTabInfo.scaleFactor) offset \(documentTabInfo.offset)")
+            logger.log("\(viewModel.key.lastPathComponent) Restore Info: scaleFactor \(documentTabInfo.scaleFactor) offset \(documentTabInfo.offset)")
             pdfView.scaleFactor = documentTabInfo.scaleFactor
             if let pdfScrollView = pdfView.scrollView {
                 pdfScrollView.setContentOffset(documentTabInfo.offset, animated: false)
@@ -63,8 +63,7 @@ final class DocumentViewController: UIViewController {
     }
     
     func close() {
-        viewModel?.clear()
-        viewModel = nil
+        viewModel.clear()
     }
     
 }
@@ -89,8 +88,8 @@ extension DocumentViewController {
     }
     
     private func configure() {
-        title = viewModel?.document?.fileURL.lastPathComponent
-        viewModel?.delegate = self
+        title = viewModel.document.fileURL.lastPathComponent
+        viewModel.delegate = self
         
         addTapGesture()
         addPanGesture()
@@ -139,7 +138,7 @@ extension DocumentViewController {
 // MARK: Actions
 extension DocumentViewController {
     func endPlayModeButtonAction() {
-        viewModel?.changeState(to: .normal)
+        viewModel.changeState(to: .normal)
     }
 }
 
@@ -160,7 +159,7 @@ extension DocumentViewController {
     @objc func setTapGesture(_ recognizer: UITapGestureRecognizer) {
         let location = recognizer.location(in: pdfView)
         
-        viewModel?.tapGestureRecognized(location: location, pdfView: pdfView)
+        viewModel.tapGestureRecognized(location: location, pdfView: pdfView)
     }
     
     @objc func setPanGesture(_ recognizer: UIPanGestureRecognizer) {
@@ -171,11 +170,11 @@ extension DocumentViewController {
             logger.log("Begin pan gesture")
             
         case .changed:
-            viewModel?.panGestureChanged(location: location, pdfView: pdfView)
+            viewModel.panGestureChanged(location: location, pdfView: pdfView)
             
         case .ended, .cancelled, .failed:
             logger.log("End pan gesture")
-            viewModel?.panGestureEnded()
+            viewModel.panGestureEnded()
             
         default:
             break

--- a/MyFlow/Views/MainView/MainViewController.swift
+++ b/MyFlow/Views/MainView/MainViewController.swift
@@ -26,12 +26,14 @@ final class MainViewController: UIViewController {
 #endif
     
     // MARK: LifeCycle
-    init(initialVC: DocumentViewController? = nil) {
+    init(initialURL: URL? = nil) {
         super.init(nibName: nil, bundle: nil)
         
         viewModel.delegate = self
-        if let initialVC = initialVC {
-            viewModel.openDocument(initialVC)
+        if let initialURL = initialURL {
+            viewModel.openDocument(with: initialURL) { [unowned self] in
+                myNavigationView.tabsAdaptor.reloadData()
+            }
         }
         myNavigationView.tabsAdaptor.dataSource = viewModel
     }

--- a/MyFlow/Views/MainView/MainViewController.swift
+++ b/MyFlow/Views/MainView/MainViewController.swift
@@ -183,7 +183,7 @@ extension MainViewController {
     }
     
     private func showDocumentView(with vc: DocumentViewController) {
-        logger.log("showDocumentView \(vc.viewModel?.key?.lastPathComponent ?? "nil")")
+        logger.log("showDocumentView \(vc.viewModel.key.lastPathComponent)")
         addChild(vc)
         vc.view.frame = documentArea.bounds
         documentArea.addSubview(vc.view)
@@ -205,7 +205,7 @@ extension MainViewController: MainViewDelegate {
     
     func updateDocumentView(with vc: DocumentViewController, info: DocumentTabInfo) {
         if let beforeState = myNavigationView.viewModel.currentVM?.nowState?.state {
-            vc.viewModel?.changeState(to: beforeState)
+            vc.viewModel.changeState(to: beforeState)
         }
         myNavigationView.viewModel.currentVM = vc.viewModel
         

--- a/MyFlow/Views/MyNavigationView/MyNavigationViewDelegate.swift
+++ b/MyFlow/Views/MyNavigationView/MyNavigationViewDelegate.swift
@@ -9,6 +9,8 @@ import Foundation
 
 
 protocol MyNavigationViewDelegate: NSObject {
+    var tabsAdaptor: DocumentTabsCollectionViewAdaptor { get }
+    
     func toggleHandlePointButton()
     func toggleAddPointsButton()
     func clearButtonState()

--- a/MyFlow/Views/MyNavigationView/Subviews/DocumentTabsCollectionViewAdaptor.swift
+++ b/MyFlow/Views/MyNavigationView/Subviews/DocumentTabsCollectionViewAdaptor.swift
@@ -54,6 +54,10 @@ final class DocumentTabsCollectionViewAdaptor: NSObject {
         
         collectionView.register(TabCell.self, forCellWithReuseIdentifier: "TabCell")
     }
+    
+    func reloadData() {
+        collectionView.reloadData()
+    }
 }
 
 


### PR DESCRIPTION
In DocumentVM, catch error if pdfDocument is nil.

### Memory leak
If open a file that's already open, there's no need to create a VC, so just take the URL.
Check url and make new document if needed.