### PR TITLE
Feature/move strategy setting view

### DIFF
--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		AFC95BA4282E6E49006E9773 /* MyNavigationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC95BA3282E6E49006E9773 /* MyNavigationView.swift */; };
 		AFC95BA8282EB4D3006E9773 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC95BA7282EB4D3006E9773 /* UIButton+.swift */; };
 		AFCAE25C283A97F300BCB486 /* MyFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCAE25B283A97F300BCB486 /* MyFlowTests.swift */; };
+		AFCBEFBF29A250E9005FD84B /* UserDefaultsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCBEFBE29A250E9005FD84B /* UserDefaultsHelper.swift */; };
 		AFCDB587293122A200E22DEA /* DocumentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB586293122A200E22DEA /* DocumentViewModel.swift */; };
 		AFCDB58D29326E6C00E22DEA /* DocumentViewStateInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB58C29326E6C00E22DEA /* DocumentViewStateInterface.swift */; };
 		AFCDB58F29326EB100E22DEA /* DocumentViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB58E29326EB100E22DEA /* DocumentViewDelegate.swift */; };
@@ -154,6 +155,7 @@
 		AFC95BA7282EB4D3006E9773 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		AFCAE259283A97F300BCB486 /* MyFlowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MyFlowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AFCAE25B283A97F300BCB486 /* MyFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFlowTests.swift; sourceTree = "<group>"; };
+		AFCBEFBE29A250E9005FD84B /* UserDefaultsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsHelper.swift; sourceTree = "<group>"; };
 		AFCDB586293122A200E22DEA /* DocumentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewModel.swift; sourceTree = "<group>"; };
 		AFCDB58C29326E6C00E22DEA /* DocumentViewStateInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewStateInterface.swift; sourceTree = "<group>"; };
 		AFCDB58E29326EB100E22DEA /* DocumentViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewDelegate.swift; sourceTree = "<group>"; };
@@ -420,6 +422,14 @@
 			path = MyFlowTests;
 			sourceTree = "<group>";
 		};
+		AFCBEFBD29A250D8005FD84B /* UserDefaultsHelper */ = {
+			isa = PBXGroup;
+			children = (
+				AFCBEFBE29A250E9005FD84B /* UserDefaultsHelper.swift */,
+			);
+			path = UserDefaultsHelper;
+			sourceTree = "<group>";
+		};
 		AFCDB58A29326E0200E22DEA /* DocumentView */ = {
 			isa = PBXGroup;
 			children = (
@@ -520,6 +530,7 @@
 		AFEC944E296EEF6400B5BEBF /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				AFCBEFBD29A250D8005FD84B /* UserDefaultsHelper */,
 				AF8936BB28367FD2001031FC /* MyError.swift */,
 				AFEC944F296EEF8000B5BEBF /* MyLogger.swift */,
 				AF1B76D52986C3DE002D9BAE /* UserActivityHelper */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		AF2F1A15294B379A0005E4B9 /* MainViewModelInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2F1A14294B379A0005E4B9 /* MainViewModelInterface.swift */; };
 		AF3C3F972843C0C2007ED4F9 /* DocumentViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3C3F962843C0C2007ED4F9 /* DocumentViewState.swift */; };
 		AF3D083129A1187600C26566 /* UITapGestureRecognizer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */; };
+		AF3D083529A118BD00C26566 /* MoveStrategyAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083429A118BD00C26566 /* MoveStrategyAnimationView.swift */; };
 		AF3D083B29A1198500C26566 /* RadioButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083A29A1198500C26566 /* RadioButtons.swift */; };
 		AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083C29A119B700C26566 /* RadioButton.swift */; };
 		AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */; };
@@ -104,6 +105,7 @@
 		AF2F1A14294B379A0005E4B9 /* MainViewModelInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModelInterface.swift; sourceTree = "<group>"; };
 		AF3C3F962843C0C2007ED4F9 /* DocumentViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewState.swift; sourceTree = "<group>"; };
 		AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITapGestureRecognizer+.swift"; sourceTree = "<group>"; };
+		AF3D083429A118BD00C26566 /* MoveStrategyAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveStrategyAnimationView.swift; sourceTree = "<group>"; };
 		AF3D083A29A1198500C26566 /* RadioButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtons.swift; sourceTree = "<group>"; };
 		AF3D083C29A119B700C26566 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
 		AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableView.swift; sourceTree = "<group>"; };
@@ -212,6 +214,22 @@
 				AF2F1A10293DB5B90005E4B9 /* MainViewModel.swift */,
 			);
 			path = MainView;
+			sourceTree = "<group>";
+		};
+		AF3D083229A118A500C26566 /* Subviews */ = {
+			isa = PBXGroup;
+			children = (
+				AF3D083329A118B200C26566 /* MoveStrategySettingView */,
+			);
+			path = Subviews;
+			sourceTree = "<group>";
+		};
+		AF3D083329A118B200C26566 /* MoveStrategySettingView */ = {
+			isa = PBXGroup;
+			children = (
+				AF3D083429A118BD00C26566 /* MoveStrategyAnimationView.swift */,
+			);
+			path = MoveStrategySettingView;
 			sourceTree = "<group>";
 		};
 		AF3D083829A1197000C26566 /* UIComponents */ = {
@@ -706,6 +724,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AF3D083529A118BD00C26566 /* MoveStrategyAnimationView.swift in Sources */,
 				AF255AA5283E95C900747FF3 /* ThumbnailCell.swift in Sources */,
 				AF8EDF85282E3F7A00CCFF19 /* Document.swift in Sources */,
 				AFC95BA4282E6E49006E9773 /* MyNavigationView.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		AF3D083129A1187600C26566 /* UITapGestureRecognizer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */; };
 		AF3D083B29A1198500C26566 /* RadioButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083A29A1198500C26566 /* RadioButtons.swift */; };
 		AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083C29A119B700C26566 /* RadioButton.swift */; };
+		AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */; };
 		AF58AF7929A1F24B00EFD8A4 /* RadioButtonShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */; };
 		AF58AF7B29A1F3A400EFD8A4 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7A29A1F3A400EFD8A4 /* UILabel+.swift */; };
 		AF65F790292E4E5F0005D9AF /* FileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF65F78F292E4E5F0005D9AF /* FileHelper.swift */; };
@@ -105,6 +106,7 @@
 		AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITapGestureRecognizer+.swift"; sourceTree = "<group>"; };
 		AF3D083A29A1198500C26566 /* RadioButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtons.swift; sourceTree = "<group>"; };
 		AF3D083C29A119B700C26566 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
+		AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableView.swift; sourceTree = "<group>"; };
 		AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtonShape.swift; sourceTree = "<group>"; };
 		AF58AF7A29A1F3A400EFD8A4 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		AF65F78F292E4E5F0005D9AF /* FileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHelper.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 		AF3D083829A1197000C26566 /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				AF3D083E29A13D0400C26566 /* Protocols */,
 				AF3D083929A1197900C26566 /* RadioButtons */,
 			);
 			path = UIComponents;
@@ -228,6 +231,14 @@
 				AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */,
 			);
 			path = RadioButtons;
+			sourceTree = "<group>";
+		};
+		AF3D083E29A13D0400C26566 /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */,
+			);
+			path = Protocols;
 			sourceTree = "<group>";
 		};
 		AF65F78E292E4E4D0005D9AF /* FileHelper */ = {
@@ -726,6 +737,7 @@
 				AF2A9ACA28615C2200D0BB24 /* DeleteCommand.swift in Sources */,
 				AFC8E25529335DCD009F9EC9 /* MyNavigationViewModelInterface.swift in Sources */,
 				AFC95BA8282EB4D3006E9773 /* UIButton+.swift in Sources */,
+				AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */,
 				AF8EDF81282E3F7A00CCFF19 /* DocumentBrowserViewController.swift in Sources */,
 				AFED0CC82844C25400FD177D /* MoveStrategy.swift in Sources */,
 				AFEC944D296C923D00B5BEBF /* PdfView+.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AF3D083B29A1198500C26566 /* RadioButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083A29A1198500C26566 /* RadioButtons.swift */; };
 		AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083C29A119B700C26566 /* RadioButton.swift */; };
 		AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */; };
+		AF58AF7529A13D6B00EFD8A4 /* SettingViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */; };
 		AF58AF7929A1F24B00EFD8A4 /* RadioButtonShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */; };
 		AF58AF7B29A1F3A400EFD8A4 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7A29A1F3A400EFD8A4 /* UILabel+.swift */; };
 		AF65F790292E4E5F0005D9AF /* FileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF65F78F292E4E5F0005D9AF /* FileHelper.swift */; };
@@ -109,6 +110,7 @@
 		AF3D083A29A1198500C26566 /* RadioButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtons.swift; sourceTree = "<group>"; };
 		AF3D083C29A119B700C26566 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
 		AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableView.swift; sourceTree = "<group>"; };
+		AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewStyle.swift; sourceTree = "<group>"; };
 		AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtonShape.swift; sourceTree = "<group>"; };
 		AF58AF7A29A1F3A400EFD8A4 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		AF65F78F292E4E5F0005D9AF /* FileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHelper.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 		AF3D083829A1197000C26566 /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				AF58AF7329A13D5E00EFD8A4 /* SettingViews */,
 				AF3D083E29A13D0400C26566 /* Protocols */,
 				AF3D083929A1197900C26566 /* RadioButtons */,
 			);
@@ -257,6 +260,14 @@
 				AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */,
 			);
 			path = Protocols;
+			sourceTree = "<group>";
+		};
+		AF58AF7329A13D5E00EFD8A4 /* SettingViews */ = {
+			isa = PBXGroup;
+			children = (
+				AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */,
+			);
+			path = SettingViews;
 			sourceTree = "<group>";
 		};
 		AF65F78E292E4E4D0005D9AF /* FileHelper */ = {
@@ -778,6 +789,7 @@
 				AFCDB59A293284A500E22DEA /* MainViewDelegate.swift in Sources */,
 				AF98A38E2832A6760035601D /* UIColor+.swift in Sources */,
 				AF2F1A15294B379A0005E4B9 /* MainViewModelInterface.swift in Sources */,
+				AF58AF7529A13D6B00EFD8A4 /* SettingViewStyle.swift in Sources */,
 				AF65F790292E4E5F0005D9AF /* FileHelper.swift in Sources */,
 				AFCDB587293122A200E22DEA /* DocumentViewModel.swift in Sources */,
 				AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083C29A119B700C26566 /* RadioButton.swift */; };
 		AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */; };
 		AF58AF7529A13D6B00EFD8A4 /* SettingViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */; };
+		AF58AF7729A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7629A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift */; };
 		AF58AF7929A1F24B00EFD8A4 /* RadioButtonShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */; };
 		AF58AF7B29A1F3A400EFD8A4 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7A29A1F3A400EFD8A4 /* UILabel+.swift */; };
 		AF65F790292E4E5F0005D9AF /* FileHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF65F78F292E4E5F0005D9AF /* FileHelper.swift */; };
@@ -111,6 +112,7 @@
 		AF3D083C29A119B700C26566 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
 		AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableView.swift; sourceTree = "<group>"; };
 		AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewStyle.swift; sourceTree = "<group>"; };
+		AF58AF7629A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableSettingViewStyle.swift; sourceTree = "<group>"; };
 		AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtonShape.swift; sourceTree = "<group>"; };
 		AF58AF7A29A1F3A400EFD8A4 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		AF65F78F292E4E5F0005D9AF /* FileHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileHelper.swift; sourceTree = "<group>"; };
@@ -266,6 +268,7 @@
 			isa = PBXGroup;
 			children = (
 				AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */,
+				AF58AF7629A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift */,
 			);
 			path = SettingViews;
 			sourceTree = "<group>";
@@ -760,6 +763,7 @@
 				AFCDB5972932735C00E22DEA /* MainViewController.swift in Sources */,
 				AFC8E24629333A4A009F9EC9 /* NowPointView.swift in Sources */,
 				AFCDB58D29326E6C00E22DEA /* DocumentViewStateInterface.swift in Sources */,
+				AF58AF7729A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift in Sources */,
 				AF1B76D72986C3F1002D9BAE /* MyUserActivity.swift in Sources */,
 				AFCDB58F29326EB100E22DEA /* DocumentViewDelegate.swift in Sources */,
 				AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		AF3C3F972843C0C2007ED4F9 /* DocumentViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3C3F962843C0C2007ED4F9 /* DocumentViewState.swift */; };
 		AF3D083129A1187600C26566 /* UITapGestureRecognizer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */; };
 		AF3D083529A118BD00C26566 /* MoveStrategyAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083429A118BD00C26566 /* MoveStrategyAnimationView.swift */; };
+		AF3D083729A118F000C26566 /* MoveStrategySettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083629A118F000C26566 /* MoveStrategySettingView.swift */; };
 		AF3D083B29A1198500C26566 /* RadioButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083A29A1198500C26566 /* RadioButtons.swift */; };
 		AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083C29A119B700C26566 /* RadioButton.swift */; };
 		AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */; };
@@ -109,6 +110,7 @@
 		AF3C3F962843C0C2007ED4F9 /* DocumentViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewState.swift; sourceTree = "<group>"; };
 		AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITapGestureRecognizer+.swift"; sourceTree = "<group>"; };
 		AF3D083429A118BD00C26566 /* MoveStrategyAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveStrategyAnimationView.swift; sourceTree = "<group>"; };
+		AF3D083629A118F000C26566 /* MoveStrategySettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveStrategySettingView.swift; sourceTree = "<group>"; };
 		AF3D083A29A1198500C26566 /* RadioButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtons.swift; sourceTree = "<group>"; };
 		AF3D083C29A119B700C26566 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
 		AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableView.swift; sourceTree = "<group>"; };
@@ -233,6 +235,7 @@
 		AF3D083329A118B200C26566 /* MoveStrategySettingView */ = {
 			isa = PBXGroup;
 			children = (
+				AF3D083629A118F000C26566 /* MoveStrategySettingView.swift */,
 				AF3D083429A118BD00C26566 /* MoveStrategyAnimationView.swift */,
 			);
 			path = MoveStrategySettingView;
@@ -380,6 +383,14 @@
 				AFAB47C72847BC050034515A /* PointHelperMemento.swift */,
 			);
 			path = Memento;
+			sourceTree = "<group>";
+		};
+		AFC7A327299CC0CD008E906D /* SettingsView */ = {
+			isa = PBXGroup;
+			children = (
+				AF3D083229A118A500C26566 /* Subviews */,
+			);
+			path = SettingsView;
 			sourceTree = "<group>";
 		};
 		AFC8E24D29334DFE009F9EC9 /* Subviews */ = {
@@ -810,6 +821,7 @@
 				AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */,
 				AFC8E2482933439F009F9EC9 /* UndoRedoArea.swift in Sources */,
 				AFC8E24F29335431009F9EC9 /* MyNavigationViewModel.swift in Sources */,
+				AF3D083729A118F000C26566 /* MoveStrategySettingView.swift in Sources */,
 				AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */,
 				AF2F1A11293DB5B90005E4B9 /* MainViewModel.swift in Sources */,
 			);

--- a/MyFlow/DocumentView/MoveStrategy/MoveStrategy.swift
+++ b/MyFlow/DocumentView/MoveStrategy/MoveStrategy.swift
@@ -8,6 +8,12 @@
 import UIKit
 import PDFKit
 
+
+enum MoveStrategyType: Int {
+    case useScrollView
+    case useGo
+}
+
 protocol MoveStrategy {
     func move(to point: PDFAnnotation)
     func moveAfter(to height: CGFloat)

--- a/MyFlow/UIComponents/Protocols/AnimatableView.swift
+++ b/MyFlow/UIComponents/Protocols/AnimatableView.swift
@@ -1,0 +1,22 @@
+//
+//  AnimatableView.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/19.
+//
+
+import UIKit
+
+
+/// protocol about the view that perform the animation.
+protocol AnimatableView: UIView {
+    /// Starts animation.
+    ///
+    /// Call this function when need to start the animation, depending on the lifecycle, etc.
+    func startAnimation()
+    
+    /// Stops animation.
+    ///
+    /// Call this function when need to stop the animation, depending on the lifecycle, etc.
+    func stopAnimation()
+}

--- a/MyFlow/UIComponents/SettingViews/ExpandableSettingViewStyle.swift
+++ b/MyFlow/UIComponents/SettingViews/ExpandableSettingViewStyle.swift
@@ -1,0 +1,100 @@
+//
+//  ExpandableSettingViewStyle.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/19.
+//
+
+import UIKit
+
+
+/// protocol about the expandable settingView. should conform `SettingViewStyle`.
+protocol ExpandableSettingViewStyle: AnyObject, SettingViewStyle {
+    /// current state of expansion.
+    var isExpanded: Bool { get set }
+    
+    /// Set the expandable style.
+    ///
+    /// When folded, only the title is visible; when expanded, the contents are expanded.
+    func setExpandable()
+    
+    /// Returns `UITapGestureRecognizer` with tab action.
+    ///
+    /// Override it if you need different behavior depending on the case.
+    func getTapGesture() -> UITapGestureRecognizer
+}
+
+
+extension ExpandableSettingViewStyle where Self: UIView {
+    func setExpandable() {
+        content.clipsToBounds = true
+        fold()
+        addGestureRecognizer(getTapGesture())
+    }
+    
+    /// This is the default behavior. Expands and collapses content according to the state.
+    func getTapGesture() -> UITapGestureRecognizer {
+        UITapGestureRecognizerWithClosure { [unowned self] in
+            isExpanded.toggle()
+            UIView.animate(withDuration: AnimateDuration.fast, delay: 0, options: .curveEaseOut) { [unowned self] in
+                if isExpanded {
+                    expand()
+                } else {
+                    fold()
+                }
+                superview?.superview?.layoutIfNeeded()
+            }
+        }
+    }
+    
+    private func expand() {
+        content.snp.remakeConstraints { make in
+            make.left.right.bottom.equalToSuperview().inset(MyOffset.padding)
+            make.top.equalTo(titleLabel.snp.bottom).offset(MyOffset.padding)
+        }
+        
+        content.alpha = 1.0
+        
+        content.layer.transform = CATransform3DIdentity
+    }
+    
+    private func fold() {
+        content.snp.remakeConstraints { make in
+            make.left.right.equalToSuperview().inset(MyOffset.padding)
+            make.top.bottom.equalTo(titleLabel.snp.bottom).offset(MyOffset.padding)
+        }
+        
+        content.alpha = 0.0
+        
+        var transform3D = CATransform3DIdentity
+        transform3D.m34 = -1.0 / 200
+        transform3D = CATransform3DRotate(transform3D, -(.pi / 4), 1, 0, 0)
+        transform3D = CATransform3DTranslate(transform3D, 0, 30, -50)
+        content.layer.transform = transform3D
+    }
+}
+
+
+extension ExpandableSettingViewStyle where Self: AnimatableView {
+    /// In case of `AnimatableView`, animation should be managed by completion.
+    func getTapGesture() -> UITapGestureRecognizer {
+        UITapGestureRecognizerWithClosure { [unowned self] in
+            isExpanded.toggle()
+            UIView.animate(withDuration: AnimateDuration.fast, delay: 0, options: .curveEaseOut) { [unowned self] in
+                if isExpanded {
+                    expand()
+                } else {
+                    fold()
+                }
+                superview?.superview?.layoutIfNeeded()
+            } completion: { [unowned self] _ in
+                if isExpanded {
+                    startAnimation()
+                } else {
+                    stopAnimation()
+                }
+            }
+        }
+    }
+}
+

--- a/MyFlow/UIComponents/SettingViews/SettingViewStyle.swift
+++ b/MyFlow/UIComponents/SettingViews/SettingViewStyle.swift
@@ -1,0 +1,61 @@
+//
+//  SettingViewStyle.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/19.
+//
+
+import UIKit
+
+
+/// protocol about the standard settingView.
+protocol SettingViewStyle {
+    /// title of the setting.
+    static var title: String { get }
+    
+    /// the label shows title.
+    var titleLabel: UILabel { get }
+    
+    /// the content view that actually perform the setup.
+    ///
+    /// Can contain buttons, radio buttons, etc.
+    var content: UIView { get }
+    
+    /// Set up a standard style.
+    
+    /// Set the style and constraints of the title and content.
+    ///
+    /// If needs to make different, it shouldn't be called.
+    func setStandardStyle()
+}
+
+extension SettingViewStyle where Self: UIView {
+    func setStandardStyle() {
+        addStandardView()
+        
+        setStandardTitleLabel()
+        setStandardContent()
+    }
+    
+    private func addStandardView() {
+        addSubview(titleLabel)
+        addSubview(content)
+    }
+    
+    private func setStandardTitleLabel() {
+        titleLabel.then {
+            $0.text = Self.title
+            $0.setHeaderStyle()
+        }.snp.makeConstraints { make in
+            make.left.top.equalToSuperview().inset(MyOffset.padding)
+        }
+    }
+    
+    private func setStandardContent() {
+        content.snp.makeConstraints { make in
+            make.left.right.bottom.equalToSuperview().inset(MyOffset.padding)
+            make.top.equalTo(titleLabel.snp.bottom).offset(MyOffset.padding)
+        }
+    }
+}
+

--- a/MyFlow/Utilities/UserDefaultsHelper/UserDefaultsHelper.swift
+++ b/MyFlow/Utilities/UserDefaultsHelper/UserDefaultsHelper.swift
@@ -1,0 +1,35 @@
+//
+//  UserDefaultsHelper.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/19.
+//
+
+import Foundation
+
+
+@propertyWrapper
+struct UserDefault<T> {
+    let key: String
+    let defaultValue: T
+    
+    var container: UserDefaults = .standard
+
+    var wrappedValue: T {
+        get {
+            return container.object(forKey: key) as? T ?? defaultValue
+        }
+        set {
+            container.set(newValue, forKey: key)
+        }
+    }
+}
+
+extension UserDefaults {
+    enum Keys: String {
+        case moveStrategy = "MoveStrategy"
+    }
+    
+    @UserDefault(key: Keys.moveStrategy.rawValue, defaultValue: MoveStrategyType.useScrollView.rawValue)
+    static var moveStrategy: Int
+}

--- a/MyFlow/Views/SettingsView/Subviews/MoveStrategySettingView/MoveStrategyAnimationView.swift
+++ b/MyFlow/Views/SettingsView/Subviews/MoveStrategySettingView/MoveStrategyAnimationView.swift
@@ -1,0 +1,156 @@
+//
+//  MoveStrategyAnimationView.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/18.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+
+extension MoveStrategyAnimationView {
+    static let pageHeight = 230.0
+    static let pointHeight = 200.0
+}
+
+
+/// Shows the moving method according to MoveStrategy as an animation.
+final class MoveStrategyAnimationView: UIView {
+    let strategy: MoveStrategyType
+    
+    /// the white view that the sheet music is based on. It doesn't actually animate.
+    lazy var pageView = UIView()
+    
+    /// the view that perform the animation.
+    lazy var pointView = UIView()
+    
+    /// point layers in pointView.
+    let points = (0..<3).map { _ in CAShapeLayer() }
+    /// wireframe of sheet music layers in pointView.
+    let wireframes = (0..<12).map { _ in CAShapeLayer() }
+    
+    init(_ strategy: MoveStrategyType) {
+        self.strategy = strategy
+        
+        super.init(frame: .zero)
+        
+        addSubviews()
+        setViews()
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+
+// MARK: LifeCycle
+extension MoveStrategyAnimationView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        addInnerShadow(opacity: 1.0, radius: 5)
+        makeSheetMusic()
+    }
+    
+    /// Place the layers at regular intervals to create the shape of a sheet music.
+    func makeSheetMusic() {
+        points.enumerated().forEach { (i, point) in
+            point.frame = .init(origin: CGPoint(x: 0, y: CGFloat(i) * MoveStrategyAnimationView.pointHeight), size: CGSize(width: pointView.frame.width, height: 5))
+        }
+        wireframes.enumerated().forEach { (i, wireframe) in
+            if i % 4 == 0 {
+                wireframe.frame = .init(origin: CGPoint(x: 0, y: CGFloat(i / 4 + 1) * MoveStrategyAnimationView.pageHeight), size: CGSize(width: pointView.frame.width, height: 10))
+            } else {
+                let pageOffset = 30.0 + CGFloat(i / 4) * MoveStrategyAnimationView.pageHeight
+                let idxOffset = CGFloat(i % 4 - 1) * 60.0
+                wireframe.frame = .init(origin: CGPoint(x: 10, y: pageOffset + idxOffset), size: CGSize(width: pointView.frame.width - 20, height: 40))
+            }
+        }
+    }
+}
+
+
+// MARK: Views
+extension MoveStrategyAnimationView {
+    private func addSubviews() {
+        addSubview(pageView)
+        addSubview(pointView)
+    }
+    
+    private func setViews() {
+        setPageView()
+        setPointView()
+        setPointViewLayers()
+    }
+    
+    private func configure() {
+        layer.cornerRadius = 10
+        backgroundColor = MyColor.pdfBackground
+        clipsToBounds = true
+    }
+    
+    private func setPageView() {
+        pageView.then {
+            $0.backgroundColor = .white
+        }.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.height.equalToSuperview()
+            make.width.equalToSuperview().multipliedBy(0.7)
+        }
+    }
+    
+    private func setPointView() {
+        pointView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.height.equalToSuperview()
+            make.width.equalTo(pageView)
+        }
+    }
+    
+    private func setPointViewLayers() {
+        points.forEach { point in
+            point.backgroundColor = UIColor.systemPink.cgColor
+            pointView.layer.addSublayer(point)
+        }
+        wireframes.enumerated().forEach { (i, wireframe) in
+            if i % 4 == 0 {
+                wireframe.backgroundColor = MyColor.pdfBackground.cgColor
+                pointView.layer.addSublayer(wireframe)
+            } else {
+                wireframe.backgroundColor = UIColor.gray.withAlphaComponent(0.3).cgColor
+                wireframe.cornerRadius = 10.0
+                pointView.layer.addSublayer(wireframe)
+            }
+        }
+    }
+}
+
+
+extension MoveStrategyAnimationView: AnimatableView {
+    func startAnimation() {
+        let duration = strategy == .useScrollView ? 1.0/10.0 : 0.0
+        UIView.animateKeyframes(withDuration: 5, delay: 0, options: [.repeat]) { [unowned self] in
+            UIView.addKeyframe(withRelativeStartTime: 1.0/8.0,
+                               relativeDuration: duration) { [unowned self] in
+                pointView.frame = pointView.frame.offsetBy(dx: 0, dy: -MoveStrategyAnimationView.pointHeight)
+            }
+            UIView.addKeyframe(withRelativeStartTime: 4.0/8.0,
+                               relativeDuration: duration) { [unowned self] in
+                pointView.frame = pointView.frame.offsetBy(dx: 0, dy: -MoveStrategyAnimationView.pointHeight)
+            }
+            UIView.addKeyframe(withRelativeStartTime: 7.0/8.0,
+                               relativeDuration: duration) { [unowned self] in
+                pointView.frame = pointView.frame.offsetBy(dx: 0, dy: MoveStrategyAnimationView.pointHeight * 2)
+            }
+        }
+    }
+    
+    func stopAnimation() {
+        pointView.layer.removeAllAnimations()
+    }
+}

--- a/MyFlow/Views/SettingsView/Subviews/MoveStrategySettingView/MoveStrategySettingView.swift
+++ b/MyFlow/Views/SettingsView/Subviews/MoveStrategySettingView/MoveStrategySettingView.swift
@@ -1,0 +1,115 @@
+//
+//  MoveStrategySettingView.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/18.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+
+extension MoveStrategySettingView {
+    static let USE_SCROLLVIEW_ID = 0
+    static let USE_GO_ID = 1
+    
+    static let labels = ["Move with scrolling", "Just move"]
+    
+    static let title = "Style to Move"
+    
+    static func changeMoveStrategy(_ id: Int) {
+        switch id {
+        case MoveStrategySettingView.USE_SCROLLVIEW_ID:
+            UserDefaults.moveStrategy = MoveStrategyType.useScrollView.rawValue
+            NotificationCenter.default.post(name: NSNotification.Name(UserDefaults.Keys.moveStrategy.rawValue), object: nil, userInfo: nil)
+        case MoveStrategySettingView.USE_GO_ID:
+            UserDefaults.moveStrategy = MoveStrategyType.useGo.rawValue
+            NotificationCenter.default.post(name: NSNotification.Name(UserDefaults.Keys.moveStrategy.rawValue), object: nil, userInfo: nil)
+        default: break
+        }
+    }
+}
+
+
+final class MoveStrategySettingView: UIView, ExpandableSettingViewStyle {
+    var isExpanded = false
+    
+    var titleLabel = UILabel()
+    
+    var content = UIView()
+    var stackView = UIStackView()
+    var animationViews = [MoveStrategyAnimationView(.useScrollView), MoveStrategyAnimationView(.useGo)]
+    var radioButtons: RadioButtons
+    
+    init() {
+        radioButtons = RadioButtons(labels: MoveStrategySettingView.labels,
+                                    with: animationViews,
+                                    defaultID: UserDefaults.moveStrategy) { id in
+            MoveStrategySettingView.changeMoveStrategy(id)
+        }
+        
+        super.init(frame: .zero)
+        
+        setStandardStyle()
+        setExpandable()
+        
+        addSubviews()
+        setViews()
+        configure()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+
+// MARK: Views
+extension MoveStrategySettingView {
+    private func addSubviews() {
+        content.addSubview(stackView)
+        
+        radioButtons.buttons.forEach { button in
+            stackView.addArrangedSubview(button)
+        }
+    }
+    
+    private func setViews() {
+        setStackView()
+    }
+    
+    private func configure() {
+#if DEBUG
+        titleLabel.backgroundColor = .systemCyan
+        content.backgroundColor = .systemPink.withAlphaComponent(0.3)
+#endif
+    }
+    
+    private func setStackView() {
+        stackView.then {
+            $0.axis = .horizontal
+            $0.alignment = .fill
+            $0.spacing = MyOffset.padding
+            $0.distribution = .fillEqually
+        }.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}
+
+
+extension MoveStrategySettingView: AnimatableView {
+    func startAnimation() {
+        animationViews.forEach { animationView in
+            animationView.startAnimation()
+        }
+    }
+    
+    func stopAnimation() {
+        animationViews.forEach { animationView in
+            animationView.stopAnimation()
+        }
+    }
+}


### PR DESCRIPTION
## Add
- `AnimatableView`: Add protocol about the view that perform the animation.
- `MoveStrategyType`
- `MoveStrategyAnimationView`: Shows the moving method according to MoveStrategy as an animation.
- `SettingViewStyle`: protocol about the standard settingView.
- `ExpandableSettingViewStyle`: protocol about the expandable settingView. should conform `SettingViewStyle`.
- `UserDefaultsHelper`: Can save moveStrategy with propertyWrapper `UserDefault`.
- `MoveStrategySettingView`: Change moveStrategy and post notification.