### PR TITLE
version 1.6.2

### DIFF
--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -1089,7 +1089,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.9;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chayujin.MyFlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1120,7 +1120,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.5.9;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.chayujin.MyFlow;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		AF3D083729A118F000C26566 /* MoveStrategySettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083629A118F000C26566 /* MoveStrategySettingView.swift */; };
 		AF3D083B29A1198500C26566 /* RadioButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083A29A1198500C26566 /* RadioButtons.swift */; };
 		AF3D083D29A119B700C26566 /* RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF3D083C29A119B700C26566 /* RadioButton.swift */; };
+		AF58533929A744A500C7D6B0 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58533829A744A500C7D6B0 /* UIApplication+.swift */; };
 		AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */; };
 		AF58AF7529A13D6B00EFD8A4 /* SettingViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */; };
 		AF58AF7729A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF58AF7629A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift */; };
@@ -61,6 +62,9 @@
 		AFAB47C02847A0830034515A /* AddCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAB47BF2847A0830034515A /* AddCommand.swift */; };
 		AFAB47C62847B26B0034515A /* MoveCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAB47C52847B26B0034515A /* MoveCommand.swift */; };
 		AFAB47C82847BC050034515A /* PointHelperMemento.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFAB47C72847BC050034515A /* PointHelperMemento.swift */; };
+		AFB458B829A6456C00FF310D /* TrueDepthThresholdSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFB458B729A6456C00FF310D /* TrueDepthThresholdSettingView.swift */; };
+		AFBAB8D329A60DB00025A0E7 /* AlertMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBAB8D229A60DB00025A0E7 /* AlertMaker.swift */; };
+		AFBAB8D629A60EBE0025A0E7 /* TrueDepthHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFBAB8D529A60EBE0025A0E7 /* TrueDepthHelper.swift */; };
 		AFC7A329299CC0DA008E906D /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC7A328299CC0DA008E906D /* SettingsView.swift */; };
 		AFC8E24629333A4A009F9EC9 /* NowPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC8E24529333A4A009F9EC9 /* NowPointView.swift */; };
 		AFC8E2482933439F009F9EC9 /* UndoRedoArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFC8E2472933439F009F9EC9 /* UndoRedoArea.swift */; };
@@ -124,6 +128,7 @@
 		AF3D083629A118F000C26566 /* MoveStrategySettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveStrategySettingView.swift; sourceTree = "<group>"; };
 		AF3D083A29A1198500C26566 /* RadioButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButtons.swift; sourceTree = "<group>"; };
 		AF3D083C29A119B700C26566 /* RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioButton.swift; sourceTree = "<group>"; };
+		AF58533829A744A500C7D6B0 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		AF58AF7129A13D2F00EFD8A4 /* AnimatableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatableView.swift; sourceTree = "<group>"; };
 		AF58AF7429A13D6B00EFD8A4 /* SettingViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewStyle.swift; sourceTree = "<group>"; };
 		AF58AF7629A13DD200EFD8A4 /* ExpandableSettingViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableSettingViewStyle.swift; sourceTree = "<group>"; };
@@ -163,6 +168,9 @@
 		AFAB47BF2847A0830034515A /* AddCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCommand.swift; sourceTree = "<group>"; };
 		AFAB47C52847B26B0034515A /* MoveCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveCommand.swift; sourceTree = "<group>"; };
 		AFAB47C72847BC050034515A /* PointHelperMemento.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelperMemento.swift; sourceTree = "<group>"; };
+		AFB458B729A6456C00FF310D /* TrueDepthThresholdSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrueDepthThresholdSettingView.swift; sourceTree = "<group>"; };
+		AFBAB8D229A60DB00025A0E7 /* AlertMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertMaker.swift; sourceTree = "<group>"; };
+		AFBAB8D529A60EBE0025A0E7 /* TrueDepthHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrueDepthHelper.swift; sourceTree = "<group>"; };
 		AFC7A328299CC0DA008E906D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		AFC8E24529333A4A009F9EC9 /* NowPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPointView.swift; sourceTree = "<group>"; };
 		AFC8E2472933439F009F9EC9 /* UndoRedoArea.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UndoRedoArea.swift; sourceTree = "<group>"; };
@@ -391,6 +399,7 @@
 				AF3D083029A1187600C26566 /* UITapGestureRecognizer+.swift */,
 				AF91FB2229A3C34500E161AC /* UIStackView+.swift */,
 				AF91FB3029A4EFBB00E161AC /* UIImage+.swift */,
+				AF58533829A744A500C7D6B0 /* UIApplication+.swift */,
 			);
 			path = MyExtensions;
 			sourceTree = "<group>";
@@ -422,6 +431,14 @@
 				AFAB47C72847BC050034515A /* PointHelperMemento.swift */,
 			);
 			path = Memento;
+			sourceTree = "<group>";
+		};
+		AFBAB8D429A60EB10025A0E7 /* TrueDepthHelper */ = {
+			isa = PBXGroup;
+			children = (
+				AFBAB8D529A60EBE0025A0E7 /* TrueDepthHelper.swift */,
+			);
+			path = TrueDepthHelper;
 			sourceTree = "<group>";
 		};
 		AFC7A327299CC0CD008E906D /* SettingsView */ = {
@@ -486,6 +503,7 @@
 			children = (
 				AFCBEFC429A28098005FD84B /* PlayModeSettingView.swift */,
 				AF91FB2829A3E06700E161AC /* PlayModeTapAreaSettingView.swift */,
+				AFB458B729A6456C00FF310D /* TrueDepthThresholdSettingView.swift */,
 			);
 			path = PlayModeSettingView;
 			sourceTree = "<group>";
@@ -591,12 +609,14 @@
 		AFEC944E296EEF6400B5BEBF /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				AFBAB8D429A60EB10025A0E7 /* TrueDepthHelper */,
 				AFCBEFBD29A250D8005FD84B /* UserDefaultsHelper */,
 				AF8936BB28367FD2001031FC /* MyError.swift */,
 				AFEC944F296EEF8000B5BEBF /* MyLogger.swift */,
 				AF1B76D52986C3DE002D9BAE /* UserActivityHelper */,
 				AF65F78E292E4E4D0005D9AF /* FileHelper */,
 				AFD6DE342833FFFF00E9FA5E /* PointHelper */,
+				AFBAB8D229A60DB00025A0E7 /* AlertMaker.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -829,6 +849,7 @@
 				AF58AF7929A1F24B00EFD8A4 /* RadioButtonShape.swift in Sources */,
 				AF1B76D22986A414002D9BAE /* UserActivityHelper.swift in Sources */,
 				AFAB47C62847B26B0034515A /* MoveCommand.swift in Sources */,
+				AFBAB8D629A60EBE0025A0E7 /* TrueDepthHelper.swift in Sources */,
 				AF3D083129A1187600C26566 /* UITapGestureRecognizer+.swift in Sources */,
 				AFAB47B728477E060034515A /* PointCommand.swift in Sources */,
 				AFCBEFBF29A250E9005FD84B /* UserDefaultsHelper.swift in Sources */,
@@ -869,8 +890,10 @@
 				AFAB47C02847A0830034515A /* AddCommand.swift in Sources */,
 				AFCBEFC529A28098005FD84B /* PlayModeSettingView.swift in Sources */,
 				AFF8DA80282F65F8005F0DED /* MyConstants.swift in Sources */,
+				AF58533929A744A500C7D6B0 /* UIApplication+.swift in Sources */,
 				AFC8E2572933686E009F9EC9 /* UIControl+.swift in Sources */,
 				AF255AA1283E809E00747FF3 /* UIDevice+.swift in Sources */,
+				AFBAB8D329A60DB00025A0E7 /* AlertMaker.swift in Sources */,
 				AF98A38C2832A6590035601D /* UIFont+.swift in Sources */,
 				AFC8E24A293345F2009F9EC9 /* PointsArea.swift in Sources */,
 				AFCDB59A293284A500E22DEA /* MainViewDelegate.swift in Sources */,
@@ -886,6 +909,7 @@
 				AF3D083729A118F000C26566 /* MoveStrategySettingView.swift in Sources */,
 				AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */,
 				AF2F1A11293DB5B90005E4B9 /* MainViewModel.swift in Sources */,
+				AFB458B829A6456C00FF310D /* TrueDepthThresholdSettingView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MyFlow/DocumentView/States/DocumentViewState.swift
+++ b/MyFlow/DocumentView/States/DocumentViewState.swift
@@ -107,7 +107,7 @@ struct AddPointsState: DocumentViewStateInterface {
 }
 
 /// Play mode. At this state, user can move to previous point with touching left side and next point with toucing right side.
-struct PlayModeState: DocumentViewStateInterface {
+class PlayModeState: DocumentViewStateInterface {
     enum TapAreaAxis: Int {
         case horizontal
         case vertical
@@ -116,6 +116,20 @@ struct PlayModeState: DocumentViewStateInterface {
     private(set) var state: DocumentViewState = .playMode
     
     private(set) weak var vm: DocumentViewModel?
+    
+    
+    var trueDepthHelper: TrueDepthHelper?
+    var isFarAway = false
+    
+    init(vm: DocumentViewModel? = nil) {
+        self.vm = vm
+        
+        if UserDefaults.useTrueDepth {
+            trueDepthHelper = TrueDepthHelper()
+            trueDepthHelper?.delegate = self
+        }
+    }
+    
     
     /// Move to previous point with touching left side and next point with toucing right side.
     func tapProcess(location: CGPoint, pdfView: PDFView) {
@@ -147,6 +161,19 @@ struct PlayModeState: DocumentViewStateInterface {
             break
         default:
             MyLogger.log("UndefinedState: from \(String(describing: self)) to \(next)", .error)
+        }
+    }
+}
+
+extension PlayModeState: TrueDepthHelperDelegate {
+    func depthDataAverageOutput(_ average: Float) {
+        if average > UserDefaults.trueDepthThreshold && !isFarAway {
+            isFarAway = true
+        } else if average < UserDefaults.trueDepthThreshold && isFarAway {
+            isFarAway = false
+            DispatchQueue.main.async { [weak self] in
+                self?.vm?.moveToNextPoint()
+            }
         }
     }
 }

--- a/MyFlow/Info.plist
+++ b/MyFlow/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIRequiresFullScreen</key>
+	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>To use TrueDepth camera for page turning</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>UIApplicationSceneManifest</key>

--- a/MyFlow/MyConstants.swift
+++ b/MyFlow/MyConstants.swift
@@ -17,8 +17,7 @@ struct MyOffset {
     static let navigationViewHeight: CGFloat = 130.0
     
     static var topPadding: CGFloat {
-        let window = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-        return window?.safeAreaInsets.top ?? 0
+        return UIApplication.shared.keyWindow?.safeAreaInsets.top ?? 0
     }
 }
 

--- a/MyFlow/MyExtensions/UIApplication+.swift
+++ b/MyFlow/MyExtensions/UIApplication+.swift
@@ -1,0 +1,32 @@
+//
+//  UIApplication+.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/23.
+//
+
+import UIKit
+
+
+extension UIApplication {
+    var keyWindow: UIWindow? {
+        connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+    
+    class func getTopViewController(base: UIViewController? = nil) -> UIViewController? {
+        let baseVC = base ?? UIApplication.shared.keyWindow?.rootViewController
+        
+        if let naviController = baseVC as? UINavigationController {
+            return getTopViewController(base: naviController.visibleViewController)
+        } else if let tabBarController = baseVC as? UITabBarController,
+                  let selected = tabBarController.selectedViewController {
+            return getTopViewController(base: selected)
+        } else if let presented = baseVC?.presentedViewController {
+            return getTopViewController(base: presented)
+        }
+        return baseVC
+    }
+}

--- a/MyFlow/MyExtensions/UILabel+.swift
+++ b/MyFlow/MyExtensions/UILabel+.swift
@@ -25,7 +25,7 @@ extension UILabel {
     
     func setBodyStyle() {
         font = .systemFont(ofSize: 16, weight: .medium)
-        textColor = MyColor.icon
+        textColor = MyColor.icon.withAlphaComponent(0.9)
         numberOfLines = 0
         textAlignment = .left
     }

--- a/MyFlow/UIComponents/SettingViews/SettingStackCell.swift
+++ b/MyFlow/UIComponents/SettingViews/SettingStackCell.swift
@@ -20,14 +20,25 @@ final class SettingStackCell: UIView {
         case withIcon(String)
     }
     
+    enum State {
+        case activated
+        case disabled
+    }
+    
+    var state: State = .activated
+    
     /// The title of the cell.
     let title: String
+    /// The additional description of the cell.
+    var body: String?
     
     lazy var label = UILabel()
     var typeView: UIView
+    lazy var bodyLabel = UILabel()
     
-    init(title: String, type: CellType) {
+    init(title: String, body: String? = nil, type: CellType) {
         self.title = title
+        self.body = body
         
         switch type {
         case .toggleable(let isSelected):
@@ -56,11 +67,32 @@ final class SettingStackCell: UIView {
 }
 
 
+// MARK: State
+extension SettingStackCell {
+    /// Update the state.
+    func setState(with state: State) {
+        self.state = state
+        
+        switch state {
+        case .activated:
+            UIView.animate(withDuration: AnimateDuration.fast, delay: 0) { [unowned self] in
+                alpha = 1.0
+            }
+        case .disabled:
+            UIView.animate(withDuration: AnimateDuration.fast, delay: 0) { [unowned self] in
+                alpha = 0.5
+            }
+        }
+    }
+}
+
+
 // MARK: Action
 extension SettingStackCell {
     /// Add a tap action to the cell.
     func addTapAction(action: @escaping () -> ()) {
-        addGestureRecognizer(UITapGestureRecognizerWithClosure {
+        addGestureRecognizer(UITapGestureRecognizerWithClosure { [unowned self] in
+            if state == .disabled { return }
             action()
         })
     }
@@ -68,10 +100,34 @@ extension SettingStackCell {
     /// If the CellType is .togglable, the toggle action is performed on cells.
     func addToggleAction(action: @escaping (Bool) -> ()) {
         addGestureRecognizer(UITapGestureRecognizerWithClosure { [unowned self] in
+            if state == .disabled { return }
             guard let toggleButton = typeView as? ToggleableButton else { return }
             toggleButton.toggle()
             action(toggleButton.isSelected)
         })
+    }
+    
+    /// Can determine the toggle state based on the current toggle state.
+    func addConditionalToggleAction(action: @escaping (Bool) -> (Bool)) {
+        addGestureRecognizer(UITapGestureRecognizerWithClosure { [unowned self] in
+            if state == .disabled { return }
+            guard let toggleButton = typeView as? ToggleableButton else { return }
+            if action(toggleButton.isSelected) {
+                toggleButton.select()
+            } else {
+                toggleButton.deselect()
+            }
+        })
+    }
+    
+    /// Can update toggle state independent of action.
+    func updateToggleState(with value: Bool) {
+        guard let toggleButton = typeView as? ToggleableButton else { return }
+        if value {
+            toggleButton.select()
+        } else {
+            toggleButton.deselect()
+        }
     }
 }
 
@@ -81,15 +137,21 @@ extension SettingStackCell {
     private func addSubviews() {
         addSubview(label)
         addSubview(typeView)
+        
+        if let _ = body {
+            addSubview(bodyLabel)
+        }
     }
     
     private func setViews() {
         setLabel()
         setTypeView()
+        setBodyLabelIfNeeded()
         
 #if DEBUG
         label.backgroundColor = .systemPink.withAlphaComponent(0.3)
         typeView.backgroundColor = .systemBlue.withAlphaComponent(0.3)
+        bodyLabel.backgroundColor = .systemOrange.withAlphaComponent(0.3)
 #endif
     }
     
@@ -98,15 +160,32 @@ extension SettingStackCell {
             $0.text = title
             $0.setSeconderyHeaderStyle()
         }.snp.makeConstraints { make in
-            make.left.top.bottom.equalToSuperview().inset(MyOffset.padding)
+            make.left.top.equalToSuperview().inset(MyOffset.padding)
         }
     }
     
     private func setTypeView() {
         typeView.snp.makeConstraints { make in
-            make.centerY.equalToSuperview()
+            make.centerY.equalTo(label)
             make.right.equalToSuperview().inset(MyOffset.padding)
             make.left.equalTo(label.snp.right).offset(MyOffset.padding)
         }
     }
+    
+    private func setBodyLabelIfNeeded() {
+        if let body = body {
+            bodyLabel.then {
+                $0.text = body
+                $0.setBodyStyle()
+            }.snp.makeConstraints { make in
+                make.left.right.bottom.equalToSuperview().inset(MyOffset.padding)
+                make.top.equalTo(label.snp.bottom).offset(MyOffset.padding)
+            }
+        } else {
+            label.snp.makeConstraints { make in
+                make.bottom.equalToSuperview().inset(MyOffset.padding)
+            }
+        }
+    }
+    
 }

--- a/MyFlow/Utilities/AlertMaker.swift
+++ b/MyFlow/Utilities/AlertMaker.swift
@@ -1,0 +1,43 @@
+//
+//  AlertMaker.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/22.
+//
+
+import UIKit
+
+
+final class AlertMaker {
+    static func showAlert(_ alertController: UIAlertController) {
+        UIApplication.getTopViewController()?.present(alertController, animated: true)
+    }
+    
+    static func trueDepthAlert() -> UIAlertController {
+        let message = "MyFlow doesn't have permission to use the camera.\nPlease change privacy settings and retry it."
+        let alertController = UIAlertController(title: "Camera Permission", message: message, preferredStyle: .alert)
+        alertController
+            .addAction(UIAlertAction(title: "Cancel",
+                                     style: .cancel,
+                                     handler: nil))
+        alertController
+            .addAction(UIAlertAction(title: "Settings",
+                                     style: .default,
+                                     handler: { _ in
+                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!,
+                                          options: [:],
+                                          completionHandler: nil)
+        }))
+        return alertController
+    }
+    
+    static func trueDepthConfigurationFailAlert() -> UIAlertController {
+        let message = "Failed to configure TrueDepth camera."
+        let alertController = UIAlertController(title: "Cannot move to next point with head bowing", message: message, preferredStyle: .alert)
+        alertController
+            .addAction(UIAlertAction(title: "Ok",
+                                     style: .cancel,
+                                     handler: nil))
+        return alertController
+    }
+}

--- a/MyFlow/Utilities/MyError.swift
+++ b/MyFlow/Utilities/MyError.swift
@@ -42,3 +42,29 @@ extension PdfError: LocalizedError {
         }
     }
 }
+
+
+enum TrueDepthError: Error {
+    case cannotFindVideoDevice
+    case cannotCreateVideoInput(Error)
+    case cannotAddVideoInputToSession
+    case cannotAddDepthDataOutputToSession
+    case cannotLockDeviceForConfiguration(Error)
+}
+
+extension TrueDepthError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .cannotFindVideoDevice:
+            return NSLocalizedString("Cannot find video device.", comment: "")
+        case .cannotCreateVideoInput(let error):
+            return NSLocalizedString("Cannot create video input: \(error.localizedDescription)", comment: "")
+        case .cannotAddVideoInputToSession:
+            return NSLocalizedString("Cannot add video input to the session.", comment: "")
+        case .cannotAddDepthDataOutputToSession:
+            return NSLocalizedString("Cannot add depth data output to the session.", comment: "")
+        case .cannotLockDeviceForConfiguration(let error):
+            return NSLocalizedString("Cannot lock device for configuration: \(error.localizedDescription)", comment: "")
+        }
+    }
+}

--- a/MyFlow/Utilities/TrueDepthHelper/TrueDepthHelper.swift
+++ b/MyFlow/Utilities/TrueDepthHelper/TrueDepthHelper.swift
@@ -1,0 +1,274 @@
+//
+//  TrueDepthHelper.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/22.
+//
+
+import AVFoundation
+
+
+protocol TrueDepthHelperDelegate: AnyObject {
+    /// Called whenever an TrueDepthHelper instance outputs a new average of depth data.
+    /// 
+    /// The result is not in Main Queue. If you want to update the UI, please do it in MainQueue.
+    ///
+    /// - Parameter average: the average of depth data.
+    func depthDataAverageOutput(_ average: Float)
+}
+
+
+class TrueDepthHelper: NSObject {
+    
+    let logger = MyLogger(category: String(describing: TrueDepthHelper.self))
+    
+    
+    weak var delegate: TrueDepthHelperDelegate?
+    
+    private enum SessionSetupResult {
+        case success
+        case notAuthorized
+        case configurationFailed
+    }
+    
+    /// The result of session setup. The session can only be started on success.
+    private var setupResult: SessionSetupResult = .success
+    
+    /// The session that processes video input from a TrueDepth camera and returns it as depth data.
+    private let session = AVCaptureSession()
+    /// The session's running state.
+    private var isSessionRunning = false
+    /// Observation of session's isRunning.
+    private var sessionObservation: NSKeyValueObservation?
+    
+    /// The queue for communication and manipulation of the session and related objects.
+    private let sessionQueue = DispatchQueue(label: "session queue", attributes: [], autoreleaseFrequency: .workItem)
+    /// Callback queue for depth data output.
+    private let dataOutputQueue = DispatchQueue(label: "data queue", qos: .userInitiated, attributes: [], autoreleaseFrequency: .workItem)
+    
+    /// The session to find built-in TrueDepth camera.
+    private let videoDeviceDiscoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInTrueDepthCamera],
+                                                                               mediaType: .video,
+                                                                               position: .front)
+    /// Input captured from video device.
+    private var videoDeviceInput: AVCaptureDeviceInput!
+    /// Output about depth data from the session.
+    private let depthDataOutput = AVCaptureDepthDataOutput()
+    
+    
+    override init() {
+        super.init()
+        
+        configure()
+        startSession()
+    }
+    
+    deinit {
+        if self.setupResult == .success {
+            NotificationCenter.default.removeObserver(self)
+            sessionObservation?.invalidate()
+        }
+    }
+}
+
+
+// MARK: Session Management
+extension TrueDepthHelper {
+    func configure() {
+        if AVCaptureDevice.authorizationStatus(for: .video) != .authorized {
+            setupResult = .notAuthorized
+            AlertMaker.showAlert(AlertMaker.trueDepthAlert())
+            return
+        }
+        
+        sessionQueue.async {
+            self.configureSession()
+        }
+    }
+    
+    func startSession() {
+        sessionQueue.async {
+            if self.setupResult != .success {
+                AlertMaker.showAlert(AlertMaker.trueDepthConfigurationFailAlert())
+                return
+            }
+            self.addObservers()
+            self.session.startRunning()
+            self.isSessionRunning = self.session.isRunning
+        }
+    }
+    
+    func stopSession() {
+        sessionQueue.async {
+            if self.setupResult == .success {
+                self.session.stopRunning()
+                self.isSessionRunning = self.session.isRunning
+            }
+        }
+    }
+}
+
+
+// MARK: Session Configure
+extension TrueDepthHelper {
+    private func configureSession() {
+        if setupResult != .success { return }
+        
+        session.beginConfiguration()
+        
+        session.sessionPreset = AVCaptureSession.Preset.vga640x480
+        
+        do {
+            let videoDevice = try prepareVideoDevice()
+            try prepareVideoDeviceInput(videoDevice)
+            try addInput()
+            try addOutput()
+            try setFormat(videoDevice)
+        } catch {
+            logger.log(error.localizedDescription, .error)
+            setupResult = .configurationFailed
+            session.commitConfiguration()
+            return
+        }
+        
+        depthDataOutput.setDelegate(self, callbackQueue: dataOutputQueue)
+        
+        session.commitConfiguration()
+    }
+    
+    private func prepareVideoDevice() throws -> AVCaptureDevice {
+        guard let videoDevice = videoDeviceDiscoverySession.devices.first else {
+            throw TrueDepthError.cannotFindVideoDevice
+        }
+        return videoDevice
+    }
+    
+    private func prepareVideoDeviceInput(_ videoDevice: AVCaptureDevice) throws {
+        do {
+            videoDeviceInput = try AVCaptureDeviceInput(device: videoDevice)
+        } catch {
+            throw TrueDepthError.cannotCreateVideoInput(error)
+        }
+    }
+    
+    private func addInput() throws {
+        guard session.canAddInput(videoDeviceInput) else {
+            throw TrueDepthError.cannotAddVideoInputToSession
+        }
+        session.addInput(videoDeviceInput)
+    }
+    
+    private func addOutput() throws {
+        if session.canAddOutput(depthDataOutput) {
+            session.addOutput(depthDataOutput)
+            depthDataOutput.isFilteringEnabled = false
+            if let connection = depthDataOutput.connection(with: .depthData) {
+                connection.isEnabled = true
+            } else {
+                logger.log("No AVCaptureConnection", .info)
+            }
+        } else {
+            throw TrueDepthError.cannotAddDepthDataOutputToSession
+        }
+    }
+    
+    private func setFormat(_ videoDevice: AVCaptureDevice) throws {
+        let depthFormats = videoDevice.activeFormat.supportedDepthDataFormats
+        let filtered = depthFormats.filter({
+            CMFormatDescriptionGetMediaSubType($0.formatDescription) == kCVPixelFormatType_DepthFloat16
+        })
+        let selectedFormat = filtered.max(by: { first, second in
+            CMVideoFormatDescriptionGetDimensions(first.formatDescription).width < CMVideoFormatDescriptionGetDimensions(second.formatDescription).width
+        })
+        
+        do {
+            try videoDevice.lockForConfiguration()
+            videoDevice.activeDepthDataFormat = selectedFormat
+            videoDevice.unlockForConfiguration()
+        } catch {
+            throw TrueDepthError.cannotLockDeviceForConfiguration(error)
+        }
+    }
+}
+
+
+// MARK: Session Observing
+extension TrueDepthHelper {
+    private func addObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(sessionRuntimeError),
+                                               name: NSNotification.Name.AVCaptureSessionRuntimeError, object: session)
+        
+        sessionObservation = session.observe(\.isRunning, options: .new) { [weak self] session, change in
+            guard let isRunning = change.newValue else { return }
+            self?.logger.log("Session running: \(isRunning)", .debug)
+        }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(sessionWasInterrupted),
+                                               name: NSNotification.Name.AVCaptureSessionWasInterrupted,
+                                               object: session)
+    }
+    
+    @objc
+    func sessionWasInterrupted(notification: NSNotification) {
+        if let userInfoValue = notification.userInfo?[AVCaptureSessionInterruptionReasonKey] as AnyObject?,
+            let reasonIntegerValue = userInfoValue.integerValue,
+            let reason = AVCaptureSession.InterruptionReason(rawValue: reasonIntegerValue) {
+            logger.log("Capture session was interrupted with reason \(reason)", .info)
+        }
+    }
+    
+    @objc
+    func sessionRuntimeError(notification: NSNotification) {
+        guard let errorValue = notification.userInfo?[AVCaptureSessionErrorKey] as? NSError else {
+            return
+        }
+        
+        let error = AVError(_nsError: errorValue)
+        logger.log("Capture session runtime error: \(error)", .error)
+        
+        if error.code == .mediaServicesWereReset {
+            sessionQueue.async {
+                if self.isSessionRunning {
+                    self.session.startRunning()
+                    self.isSessionRunning = self.session.isRunning
+                }
+            }
+        }
+    }
+}
+
+
+// MARK: AVCaptureDepthDataOutputDelegate
+extension TrueDepthHelper: AVCaptureDepthDataOutputDelegate {
+    func depthDataOutput(_ output: AVCaptureDepthDataOutput,
+                         didOutput depthData: AVDepthData,
+                         timestamp: CMTime,
+                         connection: AVCaptureConnection) {
+        let depthPixelBuffer = depthData.depthDataMap
+        
+        let average = calculateAverage(depthFrame: depthPixelBuffer)
+        
+        delegate?.depthDataAverageOutput(Float(average))
+    }
+    
+    /// Calculates average from depthFrame.
+    private func calculateAverage(depthFrame: CVPixelBuffer) -> Double {
+        var sum = 0.0
+        let width = CVPixelBufferGetWidth(depthFrame)
+        let height = CVPixelBufferGetHeight(depthFrame)
+        assert(kCVPixelFormatType_DepthFloat16 == CVPixelBufferGetPixelFormatType(depthFrame))
+        CVPixelBufferLockBaseAddress(depthFrame, .readOnly)
+        for row in (0..<height) {
+            let rowData = CVPixelBufferGetBaseAddress(depthFrame)! + row * CVPixelBufferGetBytesPerRow(depthFrame)
+            for col in (0..<width) {
+                let f = Float(rowData.assumingMemoryBound(to: Float16.self)[col])
+                if !f.isNaN {
+                    sum += Double(f)
+                }
+            }
+        }
+        CVPixelBufferUnlockBaseAddress(depthFrame, .readOnly)
+        return sum / Double((width - 1) * (height - 1)) * 100.0
+    }
+}
+

--- a/MyFlow/Utilities/UserDefaultsHelper/UserDefaultsHelper.swift
+++ b/MyFlow/Utilities/UserDefaultsHelper/UserDefaultsHelper.swift
@@ -31,6 +31,8 @@ extension UserDefaults {
         case playModeAutoScale = "PlayModeAutoScale"
         case playModeTapAreaAxis = "PlayModeTapAreaAxis"
         case playModeTapAreaLength = "PlayModeTapAreaLength"
+        case useTrueDepth = "useTrueDepth"
+        case trueDepthThreshold = "trueDepthThreshold"
     }
     
     @UserDefault(key: Keys.moveStrategy.rawValue, defaultValue: MoveStrategyType.useScrollView.rawValue)
@@ -45,5 +47,11 @@ extension UserDefaults {
     
     @UserDefault(key: Keys.playModeTapAreaLength.rawValue, defaultValue: UIScreen.main.bounds.width / 2)
     static var playModeTapAreaLength: Double
+    
+    @UserDefault(key: Keys.useTrueDepth.rawValue, defaultValue: false)
+    static var useTrueDepth: Bool
+    
+    @UserDefault(key: Keys.trueDepthThreshold.rawValue, defaultValue: 80.0)
+    static var trueDepthThreshold: Float
     
 }

--- a/MyFlow/Views/SettingsView/SettingsView.swift
+++ b/MyFlow/Views/SettingsView/SettingsView.swift
@@ -92,9 +92,7 @@ extension SettingsView {
 
 
 extension SettingsView: PlayModeSettingDelegate {
-    func showVcWithFullScreen(_ vc: UIViewController) {
-        vc.modalPresentationStyle = .fullScreen
-        
+    func present(_ vc: UIViewController) {
         self.present(vc, animated: true, completion: nil)
     }
 }

--- a/MyFlow/Views/SettingsView/Subviews/PlayModeSettingView/PlayModeSettingView.swift
+++ b/MyFlow/Views/SettingsView/Subviews/PlayModeSettingView/PlayModeSettingView.swift
@@ -11,7 +11,7 @@ import SnapKit
 
 
 protocol PlayModeSettingDelegate: NSObject {
-    func showVcWithFullScreen(_ vc: UIViewController)
+    func present(_ vc: UIViewController)
 }
 
 
@@ -81,7 +81,8 @@ extension PlayModeSettingView {
         }
         tapAreaLabel.addTapAction { [unowned self] in
             let vc = PlayModeTapAreaSettingView()
-            self.delegate?.showVcWithFullScreen(vc)
+            vc.modalPresentationStyle = .fullScreen
+            self.delegate?.present(vc)
         }
         
 #if DEBUG

--- a/MyFlow/Views/SettingsView/Subviews/PlayModeSettingView/PlayModeSettingView.swift
+++ b/MyFlow/Views/SettingsView/Subviews/PlayModeSettingView/PlayModeSettingView.swift
@@ -9,6 +9,8 @@ import UIKit
 import Then
 import SnapKit
 
+import AVFoundation
+
 
 protocol PlayModeSettingDelegate: NSObject {
     func present(_ vc: UIViewController)
@@ -19,6 +21,9 @@ extension PlayModeSettingView {
     static let title = "In PlayMode"
     static let autoScaleTitle = "Auto Scale When Start"
     static let tapAreaTitle = "Set Tap Area"
+    static let trueDepthTitle = "Move to Next Point with Head Bowing"
+    static let trueDepthBody = "You can move to the next point by lowering your head(get closer to the camera) and raising your head(move away from camera).\nA TrueDepth camera must be available."
+    static let trueDepthSensitivityTitle = "Set Head Bowing Detection Sensitivity"
     
 }
 
@@ -38,6 +43,11 @@ final class PlayModeSettingView: UIView, ExpandableSettingViewStyle {
                                           type: .toggleable(UserDefaults.playModeAutoScale))
     var tapAreaLabel = SettingStackCell(title: PlayModeSettingView.tapAreaTitle,
                                         type: .withIcon("chevron.right"))
+    var trueDepthLabel = SettingStackCell(title: PlayModeSettingView.trueDepthTitle,
+                                          body: PlayModeSettingView.trueDepthBody,
+                                          type: .toggleable(UserDefaults.useTrueDepth))
+    var trueDepthSensitivityLabel = SettingStackCell(title: PlayModeSettingView.trueDepthSensitivityTitle,
+                                                     type: .withIcon("chevron.right"))
     
     
     init() {
@@ -61,7 +71,7 @@ final class PlayModeSettingView: UIView, ExpandableSettingViewStyle {
 extension PlayModeSettingView {
     private func addSubviews() {
         content.addSubview(stackView)
-        [autoScaleLabel, tapAreaLabel].forEach { subview in
+        [autoScaleLabel, tapAreaLabel, trueDepthLabel, trueDepthSensitivityLabel].forEach { subview in
             stackView.addArrangedSubviewWithDivider(subview)
         }
         stackView.arrangedSubviews.forEach { subview in
@@ -76,6 +86,10 @@ extension PlayModeSettingView {
     }
     
     private func configure() {
+        if !UserDefaults.useTrueDepth {
+            trueDepthSensitivityLabel.setState(with: .disabled)
+        }
+        
         autoScaleLabel.addToggleAction { isSelected in
             UserDefaults.playModeAutoScale = isSelected
         }
@@ -84,7 +98,39 @@ extension PlayModeSettingView {
             vc.modalPresentationStyle = .fullScreen
             self.delegate?.present(vc)
         }
-        
+        trueDepthLabel.addConditionalToggleAction { [unowned self] nowState in
+            if nowState { // The user does not want to use
+                UserDefaults.useTrueDepth = false
+                trueDepthSensitivityLabel.setState(with: .disabled)
+                return false
+            }
+            switch AVCaptureDevice.authorizationStatus(for: .video) {
+            case .authorized: // The user has previously granted access to the camera
+                UserDefaults.useTrueDepth = true
+                trueDepthSensitivityLabel.setState(with: .activated)
+                return true
+            case .notDetermined: // The user has not yet been presented with the option to grant access
+                AVCaptureDevice.requestAccess(for: .video, completionHandler: { [weak self] granted in
+                    if granted {
+                        UserDefaults.useTrueDepth = granted
+                        DispatchQueue.main.async { [weak self] in
+                            self?.trueDepthLabel.updateToggleState(with: granted)
+                        }
+                    }
+                })
+                trueDepthSensitivityLabel.setState(with: .disabled)
+                return false
+            default: // The user has previously denied access
+                delegate?.present(AlertMaker.trueDepthAlert())
+                trueDepthSensitivityLabel.setState(with: .disabled)
+                return false
+            }
+        }
+        trueDepthSensitivityLabel.addTapAction { [unowned self] in
+            let vc = TrueDepthThresholdSettingView()
+            vc.modalPresentationStyle = .fullScreen
+            self.delegate?.present(vc)
+        }
 #if DEBUG
         titleLabel.backgroundColor = .systemCyan
         content.backgroundColor = .systemPink.withAlphaComponent(0.3)

--- a/MyFlow/Views/SettingsView/Subviews/PlayModeSettingView/TrueDepthThresholdSettingView.swift
+++ b/MyFlow/Views/SettingsView/Subviews/PlayModeSettingView/TrueDepthThresholdSettingView.swift
@@ -1,0 +1,200 @@
+//
+//  TrueDepthThresholdSettingView.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/02/22.
+//
+
+import UIKit
+import Then
+import SnapKit
+
+
+final class TrueDepthThresholdSettingView: UIViewController, AnimatableGradientBackground {
+    
+    let trueDepthHelper = TrueDepthHelper()
+    
+    lazy var stackView = UIStackView()
+    lazy var backButton = UIButton()
+    lazy var saveButton = UIButton()
+    
+    
+    lazy var detectedLabel = UILabel()
+    lazy var slider = UISlider()
+    
+    
+#if DEBUG
+    lazy var valueLabel = UILabel()
+#endif
+    
+    let gradientLayer = CAGradientLayer()
+    
+    var nowThreshold: Float = UserDefaults.trueDepthThreshold
+    var isFarAway = false
+    
+    override func viewDidLoad() {
+        trueDepthHelper.delegate = self
+        
+        super.viewDidLoad()
+        
+        setGradientLayer()
+        view.layer.addSublayer(gradientLayer)
+        
+        addSubviews()
+        setViews()
+        configure()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        gradientLayer.frame = view.frame
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        animateGradient()
+    }
+    
+}
+
+
+// MARK: Views
+extension TrueDepthThresholdSettingView {
+    private func addSubviews() {
+        view.addSubview(detectedLabel)
+        view.addSubview(slider)
+        
+        view.addSubview(stackView)
+        
+        stackView.addArrangedSubview(backButton)
+        stackView.addArrangedSubview(saveButton)
+        
+#if DEBUG
+        view.addSubview(valueLabel)
+#endif
+    }
+    
+    private func setViews() {
+        setStackView()
+        setBackButton()
+        setDetectedLabel()
+        setSlider()
+        setSaveButton()
+        
+#if DEBUG
+        setValueLabel()
+#endif
+    }
+    
+    private func configure() {
+        view.clipsToBounds = true
+        view.backgroundColor = MyColor.pageSheetBackground
+        
+        backButton.addAction { [unowned self] in
+            self.dismiss(animated: true)
+        }
+        saveButton.addAction { [unowned self] in
+            UserDefaults.trueDepthThreshold = nowThreshold
+            self.dismiss(animated: true)
+        }
+        
+        slider.addAction(for: .valueChanged) { [unowned self] in
+            nowThreshold = slider.value
+        }
+    }
+    
+    private func setStackView() {
+        stackView.then {
+            $0.axis = .horizontal
+            $0.alignment = .center
+            $0.distribution = .equalSpacing
+            $0.backgroundColor = .black.withAlphaComponent(0.1)
+            $0.layoutMargins = UIEdgeInsets(top: MyOffset.topPadding, left: MyOffset.topPadding, bottom: MyOffset.topPadding, right: MyOffset.topPadding)
+            $0.isLayoutMarginsRelativeArrangement = true
+        }.snp.makeConstraints { make in
+            make.top.left.right.equalToSuperview()
+        }
+    }
+    
+    private func setDetectedLabel() {
+        detectedLabel.then {
+            $0.text = "Detected"
+            $0.setSeconderyHeaderStyle()
+            $0.textAlignment = .center
+        }.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    private func setSlider() {
+        slider.then {
+            $0.minimumValue = 0.0
+            $0.maximumValue = 300.0
+            $0.value = nowThreshold
+        }.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview().multipliedBy(1.5)
+            make.width.equalToSuperview().multipliedBy(0.5)
+        }
+    }
+    
+    private func setBackButton() {
+        backButton.setIconStyle(systemName: "chevron.left")
+    }
+    
+    private func setSaveButton() {
+        saveButton.setIconStyle(systemName: "checkmark")
+    }
+    
+#if DEBUG
+    private func setValueLabel() {
+        valueLabel.then {
+            $0.setSeconderyHeaderStyle()
+            $0.backgroundColor = .systemOrange
+        }.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview().multipliedBy(0.5)
+        }
+    }
+#endif
+    
+}
+
+
+// MARK: Actions
+extension TrueDepthThresholdSettingView: TrueDepthHelperDelegate {
+    func depthDataAverageOutput(_ average: Float) {
+#if DEBUG
+        DispatchQueue.main.async { [weak self] in
+            self?.valueLabel.text = "DepthData Average: \(average)cm\nnowThreshold: \(self?.nowThreshold ?? 0)cm"
+        }
+#endif
+        if Float(average) > nowThreshold && !isFarAway {
+            isFarAway = true
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                UIView.animate(withDuration: AnimateDuration.normal, delay: 0) { [unowned self] in
+                    self.detectedLabel.alpha = 0.0
+                }
+                CATransaction.begin()
+                CATransaction.setAnimationDuration(AnimateDuration.normal)
+                self.gradientLayer.opacity = 0.3
+                CATransaction.commit()
+            }
+        } else if Float(average) < nowThreshold && isFarAway {
+            isFarAway = false
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                UIView.animate(withDuration: AnimateDuration.normal, delay: 0) { [unowned self] in
+                    self.detectedLabel.alpha = 1.0
+                }
+                CATransaction.begin()
+                CATransaction.setAnimationDuration(AnimateDuration.normal)
+                self.gradientLayer.opacity = 0.8
+                CATransaction.commit()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Add `TrueDepthHelper`
It takes video input using a TrueDepth camera and outputs an average of the depth data.
If there is no permission or configuration fails, an alert is displayed.

In UserDefaults, stores whether to use page turning with the TrueDepth camera and its threshold.
Can update them in the settings.