### PR TITLE
Feature/drawing tool protocol

### DIFF
--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		AFCEA35F29F0180C00AD438D /* DrawingTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA35E29F0180C00AD438D /* DrawingTool.swift */; };
 		AFCEA36229F0185000AD438D /* ToolSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36129F0185000AD438D /* ToolSettings.swift */; };
 		AFCEA36629F019D800AD438D /* RadioComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36529F019D800AD438D /* RadioComponent.swift */; };
+		AFCEA36829F01BC500AD438D /* DynamicUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
 		AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */; };
@@ -207,6 +208,7 @@
 		AFCEA35E29F0180C00AD438D /* DrawingTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingTool.swift; sourceTree = "<group>"; };
 		AFCEA36129F0185000AD438D /* ToolSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettings.swift; sourceTree = "<group>"; };
 		AFCEA36529F019D800AD438D /* RadioComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioComponent.swift; sourceTree = "<group>"; };
+		AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserDefaults.swift; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
 		AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 			isa = PBXGroup;
 			children = (
 				AFCBEFBE29A250E9005FD84B /* UserDefaultsHelper.swift */,
+				AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */,
 			);
 			path = UserDefaultsHelper;
 			sourceTree = "<group>";
@@ -893,6 +896,7 @@
 				AF98A38A2832A6380035601D /* String+.swift in Sources */,
 				AFAB47C82847BC050034515A /* PointHelperMemento.swift in Sources */,
 				AF8EDF83282E3F7A00CCFF19 /* DocumentViewController.swift in Sources */,
+				AFCEA36829F01BC500AD438D /* DynamicUserDefaults.swift in Sources */,
 				AF3C3F972843C0C2007ED4F9 /* PlayModeState.swift in Sources */,
 				AFCDB5972932735C00E22DEA /* MainViewController.swift in Sources */,
 				AFC8E24629333A4A009F9EC9 /* NowPointView.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -93,8 +93,11 @@
 		AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB59B29332B0400E22DEA /* UIView+.swift */; };
 		AFCEA35F29F0180C00AD438D /* DrawingTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA35E29F0180C00AD438D /* DrawingTool.swift */; };
 		AFCEA36229F0185000AD438D /* ToolSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36129F0185000AD438D /* ToolSettings.swift */; };
+		AFCEA36429F0187200AD438D /* HaveColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36329F0187200AD438D /* HaveColor.swift */; };
 		AFCEA36629F019D800AD438D /* RadioComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36529F019D800AD438D /* RadioComponent.swift */; };
 		AFCEA36829F01BC500AD438D /* DynamicUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */; };
+		AFCEA36A29F01CC500AD438D /* HaveWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36929F01CC500AD438D /* HaveWidth.swift */; };
+		AFCEA36C29F01CD200AD438D /* HaveOpacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
 		AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */; };
@@ -207,8 +210,11 @@
 		AFCDB59B29332B0400E22DEA /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		AFCEA35E29F0180C00AD438D /* DrawingTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingTool.swift; sourceTree = "<group>"; };
 		AFCEA36129F0185000AD438D /* ToolSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettings.swift; sourceTree = "<group>"; };
+		AFCEA36329F0187200AD438D /* HaveColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveColor.swift; sourceTree = "<group>"; };
 		AFCEA36529F019D800AD438D /* RadioComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioComponent.swift; sourceTree = "<group>"; };
 		AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserDefaults.swift; sourceTree = "<group>"; };
+		AFCEA36929F01CC500AD438D /* HaveWidth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveWidth.swift; sourceTree = "<group>"; };
+		AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveOpacity.swift; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
 		AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -585,6 +591,9 @@
 			isa = PBXGroup;
 			children = (
 				AFCEA36129F0185000AD438D /* ToolSettings.swift */,
+				AFCEA36329F0187200AD438D /* HaveColor.swift */,
+				AFCEA36929F01CC500AD438D /* HaveWidth.swift */,
+				AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */,
 			);
 			path = ToolSettings;
 			sourceTree = "<group>";
@@ -876,6 +885,7 @@
 				AF91FB2529A3CA1300E161AC /* SettingStackCell.swift in Sources */,
 				AFC8E25329335DAF009F9EC9 /* MyNavigationViewDelegate.swift in Sources */,
 				AF8936BA2836655C001031FC /* PointBuilder.swift in Sources */,
+				AFCEA36A29F01CC500AD438D /* HaveWidth.swift in Sources */,
 				AFCDB59229326ED500E22DEA /* DocumentViewModelInterface.swift in Sources */,
 				AF3D083B29A1198500C26566 /* RadioButtons.swift in Sources */,
 				AFAB47B9284795780034515A /* PointMemento.swift in Sources */,
@@ -889,6 +899,7 @@
 				AF1B76D22986A414002D9BAE /* UserActivityHelper.swift in Sources */,
 				AFAB47C62847B26B0034515A /* MoveCommand.swift in Sources */,
 				AFBAB8D629A60EBE0025A0E7 /* TrueDepthHelper.swift in Sources */,
+				AFCEA36429F0187200AD438D /* HaveColor.swift in Sources */,
 				AF3D083129A1187600C26566 /* UITapGestureRecognizer+.swift in Sources */,
 				AFAB47B728477E060034515A /* PointCommand.swift in Sources */,
 				AFCBEFBF29A250E9005FD84B /* UserDefaultsHelper.swift in Sources */,
@@ -917,6 +928,7 @@
 				AFC95BA8282EB4D3006E9773 /* UIButton+.swift in Sources */,
 				AF58AF7229A13D2F00EFD8A4 /* AnimatableView.swift in Sources */,
 				AF8EDF81282E3F7A00CCFF19 /* DocumentBrowserViewController.swift in Sources */,
+				AFCEA36C29F01CD200AD438D /* HaveOpacity.swift in Sources */,
 				AFED0CC82844C25400FD177D /* MoveStrategy.swift in Sources */,
 				AFEC944D296C923D00B5BEBF /* PdfView+.swift in Sources */,
 				AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		AFCDB5972932735C00E22DEA /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB5962932735C00E22DEA /* MainViewController.swift */; };
 		AFCDB59A293284A500E22DEA /* MainViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB599293284A500E22DEA /* MainViewDelegate.swift */; };
 		AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB59B29332B0400E22DEA /* UIView+.swift */; };
+		AFCEA36629F019D800AD438D /* RadioComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36529F019D800AD438D /* RadioComponent.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
 		AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */; };
@@ -201,6 +202,7 @@
 		AFCDB5962932735C00E22DEA /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		AFCDB599293284A500E22DEA /* MainViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewDelegate.swift; sourceTree = "<group>"; };
 		AFCDB59B29332B0400E22DEA /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		AFCEA36529F019D800AD438D /* RadioComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioComponent.swift; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
 		AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -292,6 +294,7 @@
 		AF3D083929A1197900C26566 /* RadioButtons */ = {
 			isa = PBXGroup;
 			children = (
+				AFCEA36529F019D800AD438D /* RadioComponent.swift */,
 				AF3D083A29A1198500C26566 /* RadioButtons.swift */,
 				AF3D083C29A119B700C26566 /* RadioButton.swift */,
 				AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */,
@@ -854,6 +857,7 @@
 				AFC8E25B2933826D009F9EC9 /* TabCell.swift in Sources */,
 				AF255AA3283E843A00747FF3 /* AddPointsModalViewController.swift in Sources */,
 				AF77AC9029AB48F9007CC495 /* NormalState.swift in Sources */,
+				AFCEA36629F019D800AD438D /* RadioComponent.swift in Sources */,
 				AF91FB2129A357DC00E161AC /* VerticalLineView.swift in Sources */,
 				AFC7A329299CC0DA008E906D /* SettingsView.swift in Sources */,
 				AF58AF7929A1F24B00EFD8A4 /* RadioButtonShape.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		AFCDB5972932735C00E22DEA /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB5962932735C00E22DEA /* MainViewController.swift */; };
 		AFCDB59A293284A500E22DEA /* MainViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB599293284A500E22DEA /* MainViewDelegate.swift */; };
 		AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB59B29332B0400E22DEA /* UIView+.swift */; };
+		AFCEA35F29F0180C00AD438D /* DrawingTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA35E29F0180C00AD438D /* DrawingTool.swift */; };
 		AFCEA36629F019D800AD438D /* RadioComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36529F019D800AD438D /* RadioComponent.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
@@ -202,6 +203,7 @@
 		AFCDB5962932735C00E22DEA /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		AFCDB599293284A500E22DEA /* MainViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewDelegate.swift; sourceTree = "<group>"; };
 		AFCDB59B29332B0400E22DEA /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
+		AFCEA35E29F0180C00AD438D /* DrawingTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingTool.swift; sourceTree = "<group>"; };
 		AFCEA36529F019D800AD438D /* RadioComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioComponent.swift; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
@@ -565,6 +567,14 @@
 			path = DocumentView;
 			sourceTree = "<group>";
 		};
+		AFCEA35D29F0180100AD438D /* DrawingTools */ = {
+			isa = PBXGroup;
+			children = (
+				AFCEA35E29F0180C00AD438D /* DrawingTool.swift */,
+			);
+			path = DrawingTools;
+			sourceTree = "<group>";
+		};
 		AFD6DE342833FFFF00E9FA5E /* PointHelper */ = {
 			isa = PBXGroup;
 			children = (
@@ -621,6 +631,7 @@
 		AFEC944E296EEF6400B5BEBF /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				AFCEA35D29F0180100AD438D /* DrawingTools */,
 				AFBAB8D429A60EB10025A0E7 /* TrueDepthHelper */,
 				AFCBEFBD29A250D8005FD84B /* UserDefaultsHelper */,
 				AF8936BB28367FD2001031FC /* MyError.swift */,
@@ -896,6 +907,7 @@
 				AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */,
 				AFF8DA82282FDE20005F0DED /* UIBezierPath+.swift in Sources */,
 				AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */,
+				AFCEA35F29F0180C00AD438D /* DrawingTool.swift in Sources */,
 				AFAB47BB28479F6F0034515A /* PointCommandHistory.swift in Sources */,
 				AF58AF7B29A1F3A400EFD8A4 /* UILabel+.swift in Sources */,
 				AFC8E259293368C1009F9EC9 /* DocumentTabsCollectionViewAdaptor.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		AFCDB59A293284A500E22DEA /* MainViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB599293284A500E22DEA /* MainViewDelegate.swift */; };
 		AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCDB59B29332B0400E22DEA /* UIView+.swift */; };
 		AFCEA35F29F0180C00AD438D /* DrawingTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA35E29F0180C00AD438D /* DrawingTool.swift */; };
+		AFCEA36229F0185000AD438D /* ToolSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36129F0185000AD438D /* ToolSettings.swift */; };
 		AFCEA36629F019D800AD438D /* RadioComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36529F019D800AD438D /* RadioComponent.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
@@ -204,6 +205,7 @@
 		AFCDB599293284A500E22DEA /* MainViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewDelegate.swift; sourceTree = "<group>"; };
 		AFCDB59B29332B0400E22DEA /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		AFCEA35E29F0180C00AD438D /* DrawingTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawingTool.swift; sourceTree = "<group>"; };
+		AFCEA36129F0185000AD438D /* ToolSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolSettings.swift; sourceTree = "<group>"; };
 		AFCEA36529F019D800AD438D /* RadioComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioComponent.swift; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
@@ -571,8 +573,17 @@
 			isa = PBXGroup;
 			children = (
 				AFCEA35E29F0180C00AD438D /* DrawingTool.swift */,
+				AFCEA36029F0183E00AD438D /* ToolSettings */,
 			);
 			path = DrawingTools;
+			sourceTree = "<group>";
+		};
+		AFCEA36029F0183E00AD438D /* ToolSettings */ = {
+			isa = PBXGroup;
+			children = (
+				AFCEA36129F0185000AD438D /* ToolSettings.swift */,
+			);
+			path = ToolSettings;
 			sourceTree = "<group>";
 		};
 		AFD6DE342833FFFF00E9FA5E /* PointHelper */ = {
@@ -934,6 +945,7 @@
 				AFC8E2482933439F009F9EC9 /* UndoRedoArea.swift in Sources */,
 				AFC8E24F29335431009F9EC9 /* MyNavigationViewModel.swift in Sources */,
 				AF91FB2729A3DFFE00E161AC /* AnimatableGradientBackground.swift in Sources */,
+				AFCEA36229F0185000AD438D /* ToolSettings.swift in Sources */,
 				AF3D083729A118F000C26566 /* MoveStrategySettingView.swift in Sources */,
 				AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */,
 				AF2F1A11293DB5B90005E4B9 /* MainViewModel.swift in Sources */,

--- a/MyFlow/MyConstants.swift
+++ b/MyFlow/MyConstants.swift
@@ -65,3 +65,6 @@ struct MyFont {
     static let sizePointNum = "012345678".sizeOfString(font: MyFont.pointNum!)
 }
 
+struct MyDrawingTool {
+    static let defaultColors = [UIColor.black.toInt()!, UIColor.blue.toInt()!, UIColor.red.toInt()!, UIColor.green.toInt()!]
+}

--- a/MyFlow/MyExtensions/UIColor+.swift
+++ b/MyFlow/MyExtensions/UIColor+.swift
@@ -24,4 +24,22 @@ extension UIColor {
            alpha: alpha
        )
    }
+    
+    func toInt() -> Int? {
+        var fRed : CGFloat = 0
+        var fGreen : CGFloat = 0
+        var fBlue : CGFloat = 0
+        var fAlpha: CGFloat = 0
+        if self.getRed(&fRed, green: &fGreen, blue: &fBlue, alpha: &fAlpha) {
+            let iRed = Int(fRed * 255.0)
+            let iGreen = Int(fGreen * 255.0)
+            let iBlue = Int(fBlue * 255.0)
+            let iAlpha = Int(fAlpha * 255.0)
+
+            let rgb = (iAlpha << 24) + (iRed << 16) + (iGreen << 8) + iBlue
+            return rgb
+        } else {
+            return nil
+        }
+    }
 }

--- a/MyFlow/UIComponents/RadioButtons/RadioButton.swift
+++ b/MyFlow/UIComponents/RadioButtons/RadioButton.swift
@@ -113,7 +113,7 @@ extension RadioButton {
 }
 
 
-extension RadioButton {
+extension RadioButton: RadioComponent {
     func select() {
         isSelected = true
         buttonShape.select()

--- a/MyFlow/UIComponents/RadioButtons/RadioButtons.swift
+++ b/MyFlow/UIComponents/RadioButtons/RadioButtons.swift
@@ -11,8 +11,22 @@ import SnapKit
 
 
 final class RadioButtons {
-    var buttons: [RadioButton] = []
+    var buttons: [RadioComponent] = []
     private let selectAction: (Int) -> ()
+    
+    init(with buttons: [RadioComponent],
+         defaultID: Int,
+         selectAction: @escaping (Int) -> ()) {
+        self.selectAction = selectAction
+        
+        buttons.enumerated().forEach { (id, button) in
+            button.delegate = self
+            if id == defaultID {
+                button.select()
+            }
+        }
+        self.buttons = buttons
+    }
     
     init(labels: [String],
          with contents: [UIView] = [],

--- a/MyFlow/UIComponents/RadioButtons/RadioComponent.swift
+++ b/MyFlow/UIComponents/RadioButtons/RadioComponent.swift
@@ -1,0 +1,18 @@
+//
+//  RadioComponent.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import UIKit
+
+
+protocol RadioComponent: UIView {
+    var delegate: RadioButtonDelegate? { get set }
+    var id: Int { get }
+    var isSelected: Bool { get set }
+    
+    func select()
+    func deselect()
+}

--- a/MyFlow/Utilities/DrawingTools/DrawingTool.swift
+++ b/MyFlow/Utilities/DrawingTools/DrawingTool.swift
@@ -1,0 +1,24 @@
+//
+//  DrawingTool.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+
+enum DrawingTool {
+    case pen
+    case highlighter
+    case eraser
+    
+    var icon: String {
+        switch self {
+        case .pen:
+            return "pencil.line"
+        case .highlighter:
+            return "highlighter"
+        case .eraser:
+            return "eraser.line.dashed"
+        }
+    }
+}

--- a/MyFlow/Utilities/DrawingTools/ToolSettings/HaveColor.swift
+++ b/MyFlow/Utilities/DrawingTools/ToolSettings/HaveColor.swift
@@ -1,0 +1,13 @@
+//
+//  HaveColor.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import Foundation
+
+
+protocol HaveColor: ToolSettings, AnyObject {
+    
+}

--- a/MyFlow/Utilities/DrawingTools/ToolSettings/HaveOpacity.swift
+++ b/MyFlow/Utilities/DrawingTools/ToolSettings/HaveOpacity.swift
@@ -1,0 +1,13 @@
+//
+//  HaveOpacity.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import Foundation
+
+
+protocol HaveOpacity: ToolSettings {
+    
+}

--- a/MyFlow/Utilities/DrawingTools/ToolSettings/HaveWidth.swift
+++ b/MyFlow/Utilities/DrawingTools/ToolSettings/HaveWidth.swift
@@ -1,0 +1,13 @@
+//
+//  HaveWidth.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import Foundation
+
+
+protocol HaveWidth: ToolSettings {
+    
+}

--- a/MyFlow/Utilities/DrawingTools/ToolSettings/ToolSettings.swift
+++ b/MyFlow/Utilities/DrawingTools/ToolSettings/ToolSettings.swift
@@ -1,0 +1,11 @@
+//
+//  ToolSettings.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+
+protocol ToolSettings {
+    var id: Int { get }
+}

--- a/MyFlow/Utilities/UserDefaultsHelper/DynamicUserDefaults.swift
+++ b/MyFlow/Utilities/UserDefaultsHelper/DynamicUserDefaults.swift
@@ -1,0 +1,43 @@
+//
+//  DynamicUserDefaults.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import Foundation
+
+
+struct DynamicUserDefaults {
+    enum Keys: String {
+        case toolColorSetting = "toolColorSetting"
+        case toolColorSelectedIndexSetting = "toolColorSelectedIndexSetting"
+        case toolColorwellSetting = "toolColorwellSetting"
+        case toolWidthSetting = "toolWidthSetting"
+        case toolOpacitySetting = "toolOpacitySetting"
+    }
+    
+    static var toolColorSetting = DynamicUserDefault<Int>(key: Keys.toolColorSetting.rawValue, defaultValue: 0)
+    static var toolColorSelectedIndexSetting = DynamicUserDefault<Int>(key: Keys.toolColorSelectedIndexSetting.rawValue, defaultValue: 0)
+    static var toolColorwellSetting = DynamicUserDefault<Int>(key: Keys.toolColorwellSetting.rawValue, defaultValue: 0)
+    
+    static var toolWidthSetting = DynamicUserDefault<Int>(key: Keys.toolWidthSetting.rawValue, defaultValue: 8)
+    
+    static var toolOpacitySetting = DynamicUserDefault<Double>(key: Keys.toolOpacitySetting.rawValue, defaultValue: 0.3)
+    
+}
+
+struct DynamicUserDefault<T> {
+    let key: String
+    let defaultValue: T
+    
+    var container: UserDefaults = .standard
+
+    func get(_ id: Int) -> T {
+        return container.object(forKey: "\(key)_\(id)") as? T ?? defaultValue
+    }
+    
+    func set(_ id: Int, _ newValue: T) {
+        container.set(newValue, forKey: "\(key)_\(id)")
+    }
+}


### PR DESCRIPTION
##  Add `RadioComponent`
Through the protocol, make possible to create a radio button as a custom view rather than a fixed design view.
(OCP)

## DrawingTool
- Add `DrawingTool`
- Add `ToolSettings`
  - Defines the basic elements of DrawingTool.
- Add `DynamicUserDefaults`
  - Since there can be multiple DrawingTools, make them to be saved dynamically based on their id.
- Add `HaveColor`, `HaveOpacity`, `HaveWidth`
  - Define the properties of DrawingTool as protocols.