### PR TITLE
Feature/have color

### DIFF
--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		AFCEA36A29F01CC500AD438D /* HaveWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36929F01CC500AD438D /* HaveWidth.swift */; };
 		AFCEA36C29F01CD200AD438D /* HaveOpacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */; };
 		AFCEA36E29F0294100AD438D /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36D29F0294100AD438D /* CALayer+.swift */; };
+		AFCEA37029F029F600AD438D /* RadioComponetWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36F29F029F600AD438D /* RadioComponetWrapperView.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
 		AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */; };
@@ -217,6 +218,7 @@
 		AFCEA36929F01CC500AD438D /* HaveWidth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveWidth.swift; sourceTree = "<group>"; };
 		AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveOpacity.swift; sourceTree = "<group>"; };
 		AFCEA36D29F0294100AD438D /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
+		AFCEA36F29F029F600AD438D /* RadioComponetWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioComponetWrapperView.swift; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
 		AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 				AF3D083A29A1198500C26566 /* RadioButtons.swift */,
 				AF3D083C29A119B700C26566 /* RadioButton.swift */,
 				AF58AF7829A1F24B00EFD8A4 /* RadioButtonShape.swift */,
+				AFCEA36F29F029F600AD438D /* RadioComponetWrapperView.swift */,
 			);
 			path = RadioButtons;
 			sourceTree = "<group>";
@@ -947,6 +950,7 @@
 				AFAB47C02847A0830034515A /* AddCommand.swift in Sources */,
 				AFCBEFC529A28098005FD84B /* PlayModeSettingView.swift in Sources */,
 				AFF8DA80282F65F8005F0DED /* MyConstants.swift in Sources */,
+				AFCEA37029F029F600AD438D /* RadioComponetWrapperView.swift in Sources */,
 				AF58533929A744A500C7D6B0 /* UIApplication+.swift in Sources */,
 				AFC8E2572933686E009F9EC9 /* UIControl+.swift in Sources */,
 				AF255AA1283E809E00747FF3 /* UIDevice+.swift in Sources */,

--- a/MyFlow.xcodeproj/project.pbxproj
+++ b/MyFlow.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		AFCEA36829F01BC500AD438D /* DynamicUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */; };
 		AFCEA36A29F01CC500AD438D /* HaveWidth.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36929F01CC500AD438D /* HaveWidth.swift */; };
 		AFCEA36C29F01CD200AD438D /* HaveOpacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */; };
+		AFCEA36E29F0294100AD438D /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCEA36D29F0294100AD438D /* CALayer+.swift */; };
 		AFD6DE322833B99800E9FA5E /* PointHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD6DE312833B99800E9FA5E /* PointHelper.swift */; };
 		AFE6C78D28487DD4003C4580 /* MyPDFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFE6C78C28487DD4003C4580 /* MyPDFView.swift */; };
 		AFEC944B296C422B00B5BEBF /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */; };
@@ -215,6 +216,7 @@
 		AFCEA36729F01BC500AD438D /* DynamicUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicUserDefaults.swift; sourceTree = "<group>"; };
 		AFCEA36929F01CC500AD438D /* HaveWidth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveWidth.swift; sourceTree = "<group>"; };
 		AFCEA36B29F01CD200AD438D /* HaveOpacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HaveOpacity.swift; sourceTree = "<group>"; };
+		AFCEA36D29F0294100AD438D /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		AFD6DE312833B99800E9FA5E /* PointHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointHelper.swift; sourceTree = "<group>"; };
 		AFE6C78C28487DD4003C4580 /* MyPDFView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPDFView.swift; sourceTree = "<group>"; };
 		AFEC944A296C422B00B5BEBF /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -421,6 +423,7 @@
 				AF91FB2229A3C34500E161AC /* UIStackView+.swift */,
 				AF91FB3029A4EFBB00E161AC /* UIImage+.swift */,
 				AF58533829A744A500C7D6B0 /* UIApplication+.swift */,
+				AFCEA36D29F0294100AD438D /* CALayer+.swift */,
 			);
 			path = MyExtensions;
 			sourceTree = "<group>";
@@ -962,6 +965,7 @@
 				AFC8E24F29335431009F9EC9 /* MyNavigationViewModel.swift in Sources */,
 				AF91FB2729A3DFFE00E161AC /* AnimatableGradientBackground.swift in Sources */,
 				AFCEA36229F0185000AD438D /* ToolSettings.swift in Sources */,
+				AFCEA36E29F0294100AD438D /* CALayer+.swift in Sources */,
 				AF3D083729A118F000C26566 /* MoveStrategySettingView.swift in Sources */,
 				AFCDB59C29332B0400E22DEA /* UIView+.swift in Sources */,
 				AF2F1A11293DB5B90005E4B9 /* MainViewModel.swift in Sources */,

--- a/MyFlow/MyExtensions/CALayer+.swift
+++ b/MyFlow/MyExtensions/CALayer+.swift
@@ -1,0 +1,22 @@
+//
+//  CALayer+.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import UIKit
+
+
+extension CALayer {
+    func offsetBorder(frame: CGRect? = nil, borderOffset: CGFloat = 5.0, borderColor: UIColor = MyColor.border, borderWidth: CGFloat = 2.0, cornerRadius: CGFloat = 0.0) {
+        let frame = frame ?? self.frame
+        let offsetBorder = CALayer()
+        offsetBorder.frame = CGRect(x: -borderOffset, y: -borderOffset, width: frame.size.width + 2 * borderOffset, height: frame.size.height + 2 * borderOffset)
+        offsetBorder.cornerRadius = cornerRadius
+        offsetBorder.borderColor = borderColor.cgColor
+        offsetBorder.borderWidth = borderWidth
+        offsetBorder.name = "offsetBorder"
+        insertSublayer(offsetBorder, at: 0)
+    }
+}

--- a/MyFlow/UIComponents/RadioButtons/RadioComponetWrapperView.swift
+++ b/MyFlow/UIComponents/RadioButtons/RadioComponetWrapperView.swift
@@ -1,0 +1,62 @@
+//
+//  RadioComponetWrapperView.swift
+//  MyFlow
+//
+//  Created by Yujin Cha on 2023/04/19.
+//
+
+import UIKit
+
+
+class RadioComponetWrapperView: UIView, RadioComponent {
+    weak var delegate: RadioButtonDelegate?
+    
+    var selectClosure: () -> () = {}
+    var deselectClosure: () -> () = {}
+    
+    let id: Int
+    var isSelected = false
+    
+    init(id: Int, subview: UIView, selectClosure: @escaping () -> (), deselectClosure: @escaping () -> ()) {
+        self.id = id
+        self.selectClosure = selectClosure
+        self.deselectClosure = deselectClosure
+        
+        super.init(frame: .zero)
+        
+        addSubview(subview)
+        subview.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func select() {
+        isSelected = true
+        selectClosure()
+    }
+    
+    func deselect() {
+        isSelected = false
+        deselectClosure()
+    }
+}
+
+extension RadioComponetWrapperView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let presentationFrame = layer.presentation()!.frame
+        let convertedPoint = self.convert(point, to: superview!)
+        
+        if presentationFrame.contains(convertedPoint) {
+            if !isSelected {
+                isSelected.toggle()
+                delegate?.selected(id)
+            }
+            return super.hitTest(point, with: event)
+        }
+        return nil
+    }
+}

--- a/MyFlow/Utilities/DrawingTools/ToolSettings/HaveColor.swift
+++ b/MyFlow/Utilities/DrawingTools/ToolSettings/HaveColor.swift
@@ -5,9 +5,91 @@
 //  Created by Yujin Cha on 2023/04/19.
 //
 
-import Foundation
+import UIKit
 
 
 protocol HaveColor: ToolSettings, AnyObject {
+    var colorRadioButtons: RadioButtons? { get set }
+    
+    func getColorSetting() -> UIView
+}
+
+
+extension HaveColor {
+    func getColorSetting() -> UIView {
+        let views = getCells()
+        let radioButtonComponents = getRadioButtonComponents(with: views)
+        
+        colorRadioButtons = RadioButtons(with: radioButtonComponents, defaultID: DynamicUserDefaults.toolColorSelectedIndexSetting.get(id)) { [unowned self] index in
+            DynamicUserDefaults.toolColorSelectedIndexSetting.set(id, index)
+        }
+        
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 8.0
+        
+        colorRadioButtons?.buttons.forEach { subview in
+            stackView.addArrangedSubview(subview)
+        }
+        
+        stackView.arrangedSubviews.forEach { subview in
+            subview.snp.makeConstraints { make in
+                make.width.height.equalTo(30.0)
+            }
+        }
+        
+        return stackView
+    }
+    
+    private func getCells() -> [UIView] {
+        var views = [UIView]()
+        for i in MyDrawingTool.defaultColors.indices {
+            views.append(makeDefaultCell(i))
+        }
+        views.append(makeColorWell())
+        return views
+    }
+    
+    private func getRadioButtonComponents(with views: [UIView]) -> [RadioComponetWrapperView] {
+        return views.enumerated().map { (index, subview) in
+            let radioComponent = RadioComponetWrapperView(id: index, subview: subview) { [unowned self] in
+                if 0..<4 ~= index {
+                    DynamicUserDefaults.toolColorSetting.set(id, MyDrawingTool.defaultColors[index])
+                } else {
+                    DynamicUserDefaults.toolColorSetting.set(id, DynamicUserDefaults.toolColorwellSetting.get(id))
+                }
+                DynamicUserDefaults.toolColorSelectedIndexSetting.set(id, index)
+                subview.layer.offsetBorder(frame: CGRect(origin: .zero, size: CGSize(width: 30.0, height: 30.0)), borderOffset: 3.0, cornerRadius: 5.0)
+            } deselectClosure: {
+                for sublayer in subview.layer.sublayers ?? [] {
+                    if sublayer.name == "offsetBorder" {
+                        sublayer.removeFromSuperlayer()
+                    }
+                }
+            }
+            return radioComponent
+        }
+    }
+    
+    private func makeColorWell() -> UIColorWell {
+        let colorWell = UIColorWell(frame: .zero)
+        colorWell.title = "Stroke Color"
+        colorWell.selectedColor = UIColor(rgb: DynamicUserDefaults.toolColorwellSetting.get(id))
+        colorWell.supportsAlpha = false
+        colorWell.addAction(for: .valueChanged) { [unowned self] in
+            DynamicUserDefaults.toolColorwellSetting.set(id, colorWell.selectedColor?.toInt() ?? 0)
+            DynamicUserDefaults.toolColorSetting.set(id, colorWell.selectedColor?.toInt() ?? 0)
+        }
+        return colorWell
+    }
+    
+    private func makeDefaultCell(_ index: Int) -> UIView {
+        let cell = UIView()
+        cell.backgroundColor = UIColor(rgb: MyDrawingTool.defaultColors[index])
+        cell.layer.cornerRadius = 5.0
+        cell.layer.borderColor = MyColor.icon.cgColor
+        cell.layer.borderWidth = 1.0
+        return cell
+    }
     
 }


### PR DESCRIPTION
## Add `RadioComponetWrapperView`
Wrap any view and make it a RadioComponent.
Override `hitTest()` to enable both the radio action and subview's hit action when tapped.

## Add `getColorSetting()`
Returns the settings view that can change the color of the DrawingTool.
Can choose from the default color cells and the colorWell from which the user can select a color.